### PR TITLE
docs: add develop vs main review status report

### DIFF
--- a/reviews/develop_vs_main_review.md
+++ b/reviews/develop_vs_main_review.md
@@ -1,0 +1,21 @@
+# develop 分支相对 main 分支审查报告
+
+## 结论
+当前仓库仅存在 `work` 本地分支，未发现 `develop` 与 `main` 分支引用，且未配置远程仓库，
+因此无法执行 `develop` 对比 `main` 的代码差异审查。
+
+## 已执行检查
+- `git branch -a`
+- `git show-ref --heads --tags`
+- `git remote -v`
+
+## 检查结果摘要
+1. 分支列表仅包含：`work`
+2. 本地 heads/tags 引用仅包含：`refs/heads/work`
+3. 远程仓库配置为空
+
+## 建议
+请提供以下任一条件后可继续完整审查：
+- 在当前仓库创建/拉取 `main` 与 `develop` 分支；或
+- 配置远程并允许抓取分支（如 `origin/main`、`origin/develop`）；或
+- 直接提供两分支的 patch / compare 链接。


### PR DESCRIPTION
### Motivation
- A review of changes from `develop`` to `main` was requested but the repository lacked references to those branches and had no remote configured, so an explanatory status report was needed.

### Description
- Add `reviews/develop_vs_main_review.md` which documents that only the `work` branch exists locally and that `develop` and `main` cannot be compared without additional branches/remotes.
- The report lists the exact checks performed and provides concrete next steps to enable a full `develop` vs `main` comparison.
- The file was committed to the `work` branch as part of this change.

### Testing
- Ran `git branch -a`, `git show-ref --heads --tags`, and `git remote -v`, and each command executed successfully and produced the expected empty/absence results for `develop`/`main` and remotes.
- No other automated tests were applicable to this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a4d9656f6c8323b694620f1fe9bbc1)