### PR TITLE
Add dashboard course display strategy and improve timetable UI

### DIFF
--- a/lib/app/exception/app_exception.dart
+++ b/lib/app/exception/app_exception.dart
@@ -54,9 +54,11 @@ class NetworkException extends AppException {
     );
   }
 }
+
 class JSONResolveException extends AppException {
   static const String _code = 'JSON_RESOLVE_ERROR';
-  JSONResolveException({required String message, Object? cause}) : super(_code, message, cause: cause);
+  JSONResolveException({required String message, Object? cause})
+      : super(_code, message, cause: cause);
 }
 
 class SettingsResolveException extends AppException {
@@ -67,6 +69,7 @@ class SettingsResolveException extends AppException {
 
 class SettingsValidationException extends AppException {
   static const String errorCode = 'SETTINGS_VALIDATION_ERROR';
+  static const String maxWeekInvalidFormat = 'SETTINGS_MAX_WEEK_INVALID_FORMAT';
   static const String maxWeekOutOfRange = 'SETTINGS_MAX_WEEK_OUT_OF_RANGE';
   static const String timeSlotEmpty = 'SETTINGS_TIME_SLOT_EMPTY';
   static const String timeSlotStartOutOfRange =
@@ -80,6 +83,10 @@ class SettingsValidationException extends AppException {
       'SETTINGS_TIME_SLOT_START_MINUTES_ITEM_OUT_OF_RANGE';
   static const String timeSlotStartMinutesNotIncreasing =
       'SETTINGS_TIME_SLOT_START_MINUTES_NOT_INCREASING';
+  static const String dashboardUpcomingCountOutOfRange =
+      'SETTINGS_DASHBOARD_UPCOMING_COUNT_OUT_OF_RANGE';
+  static const String dashboardUpcomingCountInvalidFormat =
+      'SETTINGS_DASHBOARD_UPCOMING_COUNT_INVALID_FORMAT';
 
   SettingsValidationException({
     required String code,

--- a/lib/features/dashboard/models/upcoming_entries_calculator.dart
+++ b/lib/features/dashboard/models/upcoming_entries_calculator.dart
@@ -1,0 +1,148 @@
+import 'package:onetj/models/dashboard_upcoming_mode.dart';
+import 'package:onetj/models/time_period_range.dart';
+import 'package:onetj/models/timetable_index.dart';
+
+/// 储存查询即将到来的课程的参数
+///
+/// [now] 当前时间
+/// [entries] 所有课程
+/// [timeSlotRanges] 节次时间范围
+/// [currentWeek] 当前周数
+/// [maxWeek] 最大周数
+/// [mode] 显示模式
+/// [count] 最多显示课程数
+class UpcomingEntriesQuery {
+  const UpcomingEntriesQuery({
+    required this.now,
+    required this.entries,
+    required this.timeSlotRanges,
+    required this.currentWeek,
+    required this.maxWeek,
+    required this.mode,
+    required this.count,
+  });
+
+  final DateTime now;
+  final List<TimetableEntry> entries;
+  final List<TimePeriodRangeData> timeSlotRanges;
+  final int currentWeek;
+  final int maxWeek;
+  final DashboardUpcomingMode mode;
+  final int count;
+}
+
+class UpcomingEntriesCalculator {
+  const UpcomingEntriesCalculator._();
+
+  static List<TimetableEntry> calculate(UpcomingEntriesQuery query) {
+    switch (query.mode) {
+      case DashboardUpcomingMode.thisWeek:
+        return _upcomingThisWeek(query);
+      case DashboardUpcomingMode.today:
+        return _upcomingToday(query);
+      case DashboardUpcomingMode.count:
+        return _upcomingByCount(query);
+    }
+  }
+
+  static List<TimetableEntry> _upcomingToday(UpcomingEntriesQuery query) {
+    if (query.entries.isEmpty) {
+      return const [];
+    }
+    return _entriesForWeekDay(
+      query: query,
+      week: query.currentWeek,
+      day: query.now.weekday,
+      onlyAfterNow: true,
+    );
+  }
+
+  static List<TimetableEntry> _upcomingThisWeek(UpcomingEntriesQuery query) {
+    if (query.entries.isEmpty) {
+      return const [];
+    }
+    final int today = query.now.weekday;
+    final List<TimetableEntry> result = [];
+    for (int day = today; day <= 7; day += 1) {
+      result.addAll(
+        _entriesForWeekDay(
+          query: query,
+          week: query.currentWeek,
+          day: day,
+          onlyAfterNow: day == today,
+        ),
+      );
+    }
+    return result;
+  }
+
+  static List<TimetableEntry> _upcomingByCount(UpcomingEntriesQuery query) {
+    if (query.entries.isEmpty ||
+        query.count <= 0 ||
+        query.currentWeek > query.maxWeek) {
+      return const [];
+    }
+    final List<TimetableEntry> result = [];
+    for (int week = query.currentWeek;
+        week <= query.maxWeek && result.length < query.count;
+        week += 1) {
+      final int startDay = week == query.currentWeek ? query.now.weekday : 1;
+      for (int day = startDay;
+          day <= 7 && result.length < query.count;
+          day += 1) {
+        final List<TimetableEntry> dayEntries = _entriesForWeekDay(
+          query: query,
+          week: week,
+          day: day,
+          onlyAfterNow: week == query.currentWeek && day == query.now.weekday,
+        );
+        for (final TimetableEntry entry in dayEntries) {
+          result.add(entry);
+          if (result.length >= query.count) {
+            break;
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  static List<TimetableEntry> _entriesForWeekDay({
+    required UpcomingEntriesQuery query,
+    required int week,
+    required int day,
+    required bool onlyAfterNow,
+  }) {
+    final List<TimetableEntry> dayEntries = query.entries
+        .where((entry) => entry.dayOfWeek == day && _matchesWeek(entry, week))
+        .toList()
+      ..sort((a, b) => a.timeStart.compareTo(b.timeStart));
+    if (!onlyAfterNow) {
+      return dayEntries;
+    }
+    dayEntries.removeWhere(
+        (entry) => !_isAfterNow(entry, query.now, query.timeSlotRanges));
+    return dayEntries;
+  }
+
+  static bool _matchesWeek(TimetableEntry entry, int week) {
+    if (entry.weeks.isEmpty) {
+      return true;
+    }
+    return entry.weeks.contains(week);
+  }
+
+  static bool _isAfterNow(
+    TimetableEntry entry,
+    DateTime now,
+    List<TimePeriodRangeData> timeSlotRanges,
+  ) {
+    final int index = entry.timeStart - 1;
+    if (index < 0 || index >= timeSlotRanges.length) {
+      return true;
+    }
+    final int startMinute = timeSlotRanges[index].startMinutes;
+    final int nowMinutes = now.hour * 60 + now.minute;
+    return startMinute > nowMinutes;
+  }
+}

--- a/lib/features/dashboard/models/upcoming_entries_calculator.dart
+++ b/lib/features/dashboard/models/upcoming_entries_calculator.dart
@@ -10,7 +10,7 @@ import 'package:onetj/models/timetable_index.dart';
 /// [currentWeek] 当前周数
 /// [maxWeek] 最大周数
 /// [mode] 显示模式
-/// [count] 最多显示课程数
+/// [count] 最多显示课程数，仅在 [DashboardUpcomingMode.count] 模式下生效
 class UpcomingEntriesQuery {
   const UpcomingEntriesQuery({
     required this.now,

--- a/lib/features/dashboard/view_models/dashboard_view_model.dart
+++ b/lib/features/dashboard/view_models/dashboard_view_model.dart
@@ -1,15 +1,17 @@
 import 'dart:async';
 
-import 'package:onetj/models/base_model.dart';
-import 'package:onetj/models/event_model.dart';
-import 'package:onetj/models/time_period_range.dart';
 import 'package:onetj/features/dashboard/models/dashboard_model.dart';
-import 'package:onetj/models/timetable_index.dart';
+import 'package:onetj/features/dashboard/models/upcoming_entries_calculator.dart';
+import 'package:onetj/models/base_model.dart';
+import 'package:onetj/models/dashboard_upcoming_mode.dart';
+import 'package:onetj/models/event_model.dart';
 import 'package:onetj/models/settings_defaults.dart';
-import 'package:onetj/repo/student_info_repository.dart';
-import 'package:onetj/repo/school_calendar_repository.dart';
+import 'package:onetj/models/time_period_range.dart';
+import 'package:onetj/models/timetable_index.dart';
 import 'package:onetj/repo/course_schedule_repository.dart';
+import 'package:onetj/repo/school_calendar_repository.dart';
 import 'package:onetj/repo/settings_repository.dart';
+import 'package:onetj/repo/student_info_repository.dart';
 import 'package:onetj/services/timetable_index_builder.dart';
 
 class DashboardViewModel extends BaseViewModel {
@@ -28,10 +30,15 @@ class DashboardViewModel extends BaseViewModel {
   final StreamController<UiEvent> _eventController;
   StreamSubscription<SettingsData>? _settingsSub;
   Stream<UiEvent> get events => _eventController.stream;
+
   String? _departmentName;
   SchoolCalendarData? _calendar;
   List<TimetableEntry> _timetableEntries = const [];
   List<TimePeriodRangeData> _timeSlotRanges = kDefaultTimeSlotRanges;
+  DashboardUpcomingMode _upcomingMode = kDefaultDashboardUpcomingMode;
+  int _upcomingCount = kDefaultDashboardUpcomingCount;
+  int _maxWeek = kDefaultMaxWeek;
+
   Object? _studentError;
   Object? _calendarError;
   Object? _timetableError;
@@ -49,8 +56,25 @@ class DashboardViewModel extends BaseViewModel {
   bool get calendarLoading => _calendarLoading;
   bool get timetableLoading => _timetableLoading;
   List<TimePeriodRangeData> get timeSlotRanges => _timeSlotRanges;
-  List<TimetableEntry> get upcomingEntries =>
-      _upcomingEntries(now: DateTime.now(), limit: 3);
+  DashboardUpcomingMode get upcomingMode => _upcomingMode;
+  List<TimetableEntry> buildUpcomingEntries({DateTime? now}) {
+    final int? currentWeek = _calendar?.week;
+    if (currentWeek == null || _timetableEntries.isEmpty) {
+      return const [];
+    }
+    final DateTime clock = now ?? DateTime.now();
+    return UpcomingEntriesCalculator.calculate(
+      UpcomingEntriesQuery(
+        now: clock,
+        entries: _timetableEntries,
+        timeSlotRanges: _timeSlotRanges,
+        currentWeek: currentWeek,
+        maxWeek: _maxWeek,
+        mode: _upcomingMode,
+        count: _upcomingCount,
+      ),
+    );
+  }
 
   Future<void> load() async {
     _studentLoading = true;
@@ -68,57 +92,6 @@ class DashboardViewModel extends BaseViewModel {
     ]);
   }
 
-  /// 获取将要到来的课程
-  ///
-  /// [now] 相对于的时间，一般填当前时间
-  /// [limit] 最多返回的课程数量
-  List<TimetableEntry> _upcomingEntries({
-    required DateTime now,
-    int limit = 3,
-  }) {
-    final int? currentWeek = _calendar?.week;
-    if (_timetableEntries.isEmpty || currentWeek == null || limit <= 0) {
-      // TODO: 提示用户没有课程
-      return const [];
-    }
-    final int today = now.weekday;
-    final List<TimetableEntry> result = [];
-    for (int day = today; day <= 7 && result.length < limit; day += 1) {
-      final List<TimetableEntry> dayEntries = _timetableEntries
-          .where((entry) =>
-              entry.dayOfWeek == day && _matchesWeek(entry, currentWeek))
-          .toList()
-        ..sort((a, b) => a.timeStart.compareTo(b.timeStart));
-      if (day == today) {
-        dayEntries.removeWhere((entry) => !_isAfterNow(entry, now));
-      }
-      for (final entry in dayEntries) {
-        result.add(entry);
-        if (result.length >= limit) {
-          break;
-        }
-      }
-    }
-    return result;
-  }
-
-  bool _matchesWeek(TimetableEntry entry, int currentWeek) {
-    if (entry.weeks.isEmpty) {
-      return true;
-    }
-    return entry.weeks.contains(currentWeek);
-  }
-
-  bool _isAfterNow(TimetableEntry entry, DateTime now) {
-    final int index = entry.timeStart - 1;
-    if (index < 0 || index >= _timeSlotRanges.length) {
-      return true;
-    }
-    final int startMinute = _timeSlotRanges[index].startMinutes;
-    final int nowMinutes = now.hour * 60 + now.minute;
-    return startMinute > nowMinutes;
-  }
-
   Future<void> loadSettings() async {
     try {
       final SettingsData data = await _settingsRepository.getSettings();
@@ -132,17 +105,33 @@ class DashboardViewModel extends BaseViewModel {
 
   void _handleSettingsChanged(SettingsData data) {
     final List<TimePeriodRangeData> nextTimeSlotRanges =
-        List<TimePeriodRangeData>.from(
-      data.timeSlotRanges,
-    );
-    if (_sameTimeSlotRanges(_timeSlotRanges, nextTimeSlotRanges)) {
+        List<TimePeriodRangeData>.from(data.timeSlotRanges);
+    final bool timeSlotChanged =
+        !_sameTimeSlotRanges(_timeSlotRanges, nextTimeSlotRanges);
+    final bool modeChanged = _upcomingMode != data.dashboardUpcomingMode;
+    final bool countChanged = _upcomingCount != data.dashboardUpcomingCount;
+    final bool maxWeekChanged = _maxWeek != data.maxWeek;
+
+    if (!timeSlotChanged && !modeChanged && !countChanged && !maxWeekChanged) {
       return;
     }
-    _timeSlotRanges = nextTimeSlotRanges;
+    if (timeSlotChanged) {
+      _timeSlotRanges = nextTimeSlotRanges;
+    }
+    if (modeChanged) {
+      _upcomingMode = data.dashboardUpcomingMode;
+    }
+    if (countChanged) {
+      _upcomingCount = data.dashboardUpcomingCount;
+    }
+    if (maxWeekChanged) {
+      _maxWeek = data.maxWeek;
+    }
     notifyListeners();
   }
 
-  bool _sameTimeSlotRanges(List<TimePeriodRangeData> a, List<TimePeriodRangeData> b) {
+  bool _sameTimeSlotRanges(
+      List<TimePeriodRangeData> a, List<TimePeriodRangeData> b) {
     if (a.length != b.length) {
       return false;
     }

--- a/lib/features/dashboard/views/dashboard_view.dart
+++ b/lib/features/dashboard/views/dashboard_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:onetj/features/dashboard/view_models/dashboard_view_model.dart';
+import 'package:onetj/models/dashboard_upcoming_mode.dart';
 import 'package:onetj/models/event_model.dart';
 import 'package:onetj/models/time_period_range.dart';
 import 'package:onetj/models/timetable_index.dart';
@@ -71,12 +72,12 @@ class _DashboardViewState extends State<DashboardView> {
             style: Theme.of(context).textTheme.titleMedium,
           ),
           const SizedBox(height: 8),
-          if (_viewModel.timetableLoading)
+          if (_viewModel.timetableLoading || _viewModel.calendarLoading)
             const LinearProgressIndicator()
           else
             _buildUpcomingSection(
               context,
-              entries: _viewModel.upcomingEntries,
+              entries: _viewModel.buildUpcomingEntries(),
             ),
         ],
       ),
@@ -143,7 +144,7 @@ class _DashboardViewState extends State<DashboardView> {
     if (entries.isEmpty) {
       return _EmptyState(
         icon: Icons.event_available,
-        title: l10n.dashboardUpcomingEmpty,
+        title: _dashboardUpcomingEmptyText(l10n, _viewModel.upcomingMode),
       );
     }
     return Column(
@@ -164,6 +165,20 @@ class _DashboardViewState extends State<DashboardView> {
           )
           .toList(),
     );
+  }
+
+  String _dashboardUpcomingEmptyText(
+    AppLocalizations l10n,
+    DashboardUpcomingMode mode,
+  ) {
+    switch (mode) {
+      case DashboardUpcomingMode.thisWeek:
+        return l10n.dashboardUpcomingEmptyThisWeek;
+      case DashboardUpcomingMode.today:
+        return l10n.dashboardUpcomingEmptyToday;
+      case DashboardUpcomingMode.count:
+        return l10n.dashboardUpcomingEmptyByCount;
+    }
   }
 
   String _weekdayLabel(AppLocalizations l10n, int dayOfWeek) {

--- a/lib/features/dashboard/views/dashboard_view.dart
+++ b/lib/features/dashboard/views/dashboard_view.dart
@@ -289,35 +289,37 @@ class _UpcomingCard extends StatelessWidget {
           color: colors.outlineVariant,
         ),
       ),
-      child: IntrinsicHeight(
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _TimeBadge(label: timeLabel),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 8),
-                  _MetaRow(
-                    icon: Icons.room_outlined,
-                    label: roomLabel,
-                  ),
-                  const SizedBox(height: 4),
-                  _MetaRow(
-                    icon: Icons.person_outline,
-                    label: teacherLabel,
-                  ),
-                ],
-              ),
+      child: Stack(
+        children: [
+          Positioned(
+            top: 0,
+            bottom: 0,
+            left: 0,
+            child: _TimeBadge(label: timeLabel),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 107),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                _MetaRow(
+                  icon: Icons.room_outlined,
+                  label: roomLabel,
+                ),
+                const SizedBox(height: 4),
+                _MetaRow(
+                  icon: Icons.person_outline,
+                  label: teacherLabel,
+                ),
+              ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -331,21 +333,23 @@ class _TimeBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
-    return Container(
-      width: 95,
-      height: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 8),
-      alignment: Alignment.centerLeft,
-      decoration: BoxDecoration(
-        color: colors.surface,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: colors.outlineVariant,
+    return Padding(
+      padding: const EdgeInsets.only(right: 12),
+      child: Container(
+        width: 95,
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        alignment: Alignment.centerLeft,
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: colors.outlineVariant,
+          ),
         ),
-      ),
-      child: Text(
-        label,
-        style: Theme.of(context).textTheme.bodySmall,
+        child: Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
       ),
     );
   }

--- a/lib/features/dashboard/views/dashboard_view.dart
+++ b/lib/features/dashboard/views/dashboard_view.dart
@@ -155,7 +155,7 @@ class _DashboardViewState extends State<DashboardView> {
                   ? entry.courseName
                   : 'Unknown course',
               timeLabel:
-                  '${_weekdayLabel(l10n, entry.dayOfWeek)} · ${_formatTimeRange(entry, _viewModel.timeSlotRanges)}',
+                  '${_weekdayLabel(l10n, entry.dayOfWeek)}\n${_formatTimeRange(entry, _viewModel.timeSlotRanges)}',
               roomLabel: entry.roomIdI18n.isNotEmpty
                   ? entry.roomIdI18n
                   : entry.roomLabel,
@@ -289,33 +289,35 @@ class _UpcomingCard extends StatelessWidget {
           color: colors.outlineVariant,
         ),
       ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _TimeBadge(label: timeLabel),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  title,
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 8),
-                _MetaRow(
-                  icon: Icons.room_outlined,
-                  label: roomLabel,
-                ),
-                const SizedBox(height: 4),
-                _MetaRow(
-                  icon: Icons.person_outline,
-                  label: teacherLabel,
-                ),
-              ],
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _TimeBadge(label: timeLabel),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  _MetaRow(
+                    icon: Icons.room_outlined,
+                    label: roomLabel,
+                  ),
+                  const SizedBox(height: 4),
+                  _MetaRow(
+                    icon: Icons.person_outline,
+                    label: teacherLabel,
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -330,8 +332,10 @@ class _TimeBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
     return Container(
-      width: 88,
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+      width: 95,
+      height: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      alignment: Alignment.centerLeft,
       decoration: BoxDecoration(
         color: colors.surface,
         borderRadius: BorderRadius.circular(12),

--- a/lib/features/dashboard/views/dashboard_view.dart
+++ b/lib/features/dashboard/views/dashboard_view.dart
@@ -11,6 +11,11 @@ import 'package:onetj/models/timetable_index.dart';
 import 'package:onetj/models/time_slot.dart';
 import 'package:onetj/repo/school_calendar_repository.dart';
 
+const double _kUpcomingTimeBadgeWidth = 95;
+const double _kUpcomingTimeBadgeGap = 12;
+const double _kUpcomingContentLeftInset =
+    _kUpcomingTimeBadgeWidth + _kUpcomingTimeBadgeGap;
+
 class DashboardView extends StatefulWidget {
   const DashboardView({super.key});
 
@@ -298,7 +303,7 @@ class _UpcomingCard extends StatelessWidget {
             child: _TimeBadge(label: timeLabel),
           ),
           Padding(
-            padding: const EdgeInsets.only(left: 107),
+            padding: const EdgeInsets.only(left: _kUpcomingContentLeftInset),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -334,9 +339,9 @@ class _TimeBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
     return Padding(
-      padding: const EdgeInsets.only(right: 12),
+      padding: const EdgeInsets.only(right: _kUpcomingTimeBadgeGap),
       child: Container(
-        width: 95,
+        width: _kUpcomingTimeBadgeWidth,
         padding: const EdgeInsets.symmetric(horizontal: 8),
         alignment: Alignment.centerLeft,
         decoration: BoxDecoration(

--- a/lib/features/settings/models/settings_model.dart
+++ b/lib/features/settings/models/settings_model.dart
@@ -33,7 +33,7 @@ class SettingsModel {
   ///
   /// throw [SettingsValidationException] 解析非数值
   static int parseMaxWeekText(String text) {
-    return _parsePositiveInt(
+    return _parseInt(
       text: text,
       code: SettingsValidationException.maxWeekInvalidFormat,
       fieldName: 'maxWeek',
@@ -44,7 +44,7 @@ class SettingsModel {
   ///
   /// throw [SettingsValidationException] 解析非数值
   static int parseDashboardUpcomingCountText(String text) {
-    return _parsePositiveInt(
+    return _parseInt(
       text: text,
       code: SettingsValidationException.dashboardUpcomingCountInvalidFormat,
       fieldName: 'dashboardUpcomingCount',
@@ -74,10 +74,10 @@ class SettingsModel {
     settings_validation.validateTimeSlotRanges(values);
   }
 
-  /// 从文本中解析正整数
+  /// 从文本中解析整数
   ///
   /// throw [SettingsValidationException] 解析非数值
-  static int _parsePositiveInt({
+  static int _parseInt({
     required String text,
     required String code,
     required String fieldName,

--- a/lib/features/settings/models/settings_model.dart
+++ b/lib/features/settings/models/settings_model.dart
@@ -1,4 +1,5 @@
 import 'package:onetj/app/exception/app_exception.dart';
+import 'package:onetj/models/settings_defaults.dart';
 import 'package:onetj/models/settings_validation.dart' as settings_validation;
 import 'package:onetj/models/time_period_range.dart';
 import 'package:onetj/repo/settings_repository.dart';
@@ -7,12 +8,13 @@ class SettingsModel {
   static void validateSettings(SettingsData settings) {
     validateMaxWeek(settings.maxWeek);
     validateTimeSlotRanges(settings.timeSlotRanges);
+    validateDashboardUpcomingCount(settings.dashboardUpcomingCount);
   }
 
   /// 校验是否符合最大周数范围
-  /// 
+  ///
   /// 最大周数范围为1-52
-  /// 
+  ///
   /// throw [SettingsValidationException]
   static void validateMaxWeek(int value) {
     if (value < 1 || value > 52) {
@@ -27,15 +29,66 @@ class SettingsModel {
     settings_validation.validateTimeSlotStartMinutes(values);
   }
 
+  /// 从文本中解析最大周数
+  ///
+  /// throw [SettingsValidationException] 解析非数值
+  static int parseMaxWeekText(String text) {
+    return _parsePositiveInt(
+      text: text,
+      code: SettingsValidationException.maxWeekInvalidFormat,
+      fieldName: 'maxWeek',
+    );
+  }
+
+  /// 从文本中解析待办事项显示数量
+  ///
+  /// throw [SettingsValidationException] 解析非数值
+  static int parseDashboardUpcomingCountText(String text) {
+    return _parsePositiveInt(
+      text: text,
+      code: SettingsValidationException.dashboardUpcomingCountInvalidFormat,
+      fieldName: 'dashboardUpcomingCount',
+    );
+  }
+
   static List<TimePeriodRangeData> buildTimeSlotRangesFromStartMinutes(
     List<int> starts,
   ) {
     return settings_validation.buildTimeSlotRangesFromStartMinutes(starts);
   }
+
+  static void validateDashboardUpcomingCount(int value) {
+    if (value < kMinDashboardUpcomingCount ||
+        value > kMaxDashboardUpcomingCount) {
+      throw SettingsValidationException(
+        code: SettingsValidationException.dashboardUpcomingCountOutOfRange,
+        message: 'dashboardUpcomingCount out of range',
+      );
+    }
+  }
+
   /// 校验时间槽范围是否符合要求
-  /// 
+  ///
   /// throw [SettingsValidationException]
   static void validateTimeSlotRanges(List<TimePeriodRangeData> values) {
     settings_validation.validateTimeSlotRanges(values);
+  }
+
+  /// 从文本中解析正整数
+  ///
+  /// throw [SettingsValidationException] 解析非数值
+  static int _parsePositiveInt({
+    required String text,
+    required String code,
+    required String fieldName,
+  }) {
+    final int? value = int.tryParse(text.trim());
+    if (value == null) {
+      throw SettingsValidationException(
+        code: code,
+        message: '$fieldName is not a valid number',
+      );
+    }
+    return value;
   }
 }

--- a/lib/features/settings/view_models/settings_view_model.dart
+++ b/lib/features/settings/view_models/settings_view_model.dart
@@ -118,9 +118,11 @@ class SettingsViewModel extends BaseViewModel {
     try {
       final int maxWeek = SettingsModel.parseMaxWeekText(maxWeekText);
       final int dashboardUpcomingCount =
-          SettingsModel.parseDashboardUpcomingCountText(
-        dashboardUpcomingCountText,
-      );
+          dashboardUpcomingMode == DashboardUpcomingMode.count
+          ? SettingsModel.parseDashboardUpcomingCountText(
+              dashboardUpcomingCountText,
+            )
+          : _settingsData.dashboardUpcomingCount;
       SettingsModel.validateMaxWeek(maxWeek);
       SettingsModel.validateTimeSlotRanges(editedTimeSlotRanges);
       SettingsModel.validateDashboardUpcomingCount(dashboardUpcomingCount);

--- a/lib/features/settings/view_models/settings_view_model.dart
+++ b/lib/features/settings/view_models/settings_view_model.dart
@@ -5,6 +5,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:onetj/app/exception/app_exception.dart';
 import 'package:onetj/app/constant/route_paths.dart';
 import 'package:onetj/app/logging/app_logger.dart';
+import 'package:onetj/models/dashboard_upcoming_mode.dart';
 import 'package:onetj/models/settings_defaults.dart';
 import 'package:onetj/features/settings/models/event.dart';
 import 'package:onetj/features/settings/models/settings_model.dart';
@@ -27,6 +28,8 @@ class SettingsViewModel extends BaseViewModel {
   SettingsData _settingsData = SettingsData(
     maxWeek: kDefaultMaxWeek,
     timeSlotRanges: kDefaultTimeSlotRanges,
+    dashboardUpcomingMode: kDefaultDashboardUpcomingMode,
+    dashboardUpcomingCount: kDefaultDashboardUpcomingCount,
   );
   bool _settingsLoading = true;
   bool _settingsSaving = false;
@@ -103,21 +106,31 @@ class SettingsViewModel extends BaseViewModel {
   }
 
   Future<void> saveSettings({
-    required int maxWeek,
+    required String maxWeekText,
     required List<TimePeriodRangeData> editedTimeSlotRanges,
+    required DashboardUpcomingMode dashboardUpcomingMode,
+    required String dashboardUpcomingCountText,
   }) async {
     AppLogger.logUiAction(feature: 'Settings', action: 'save_started');
     _settingsSaving = true;
     errorMessage = null;
     notifyListeners();
     try {
+      final int maxWeek = SettingsModel.parseMaxWeekText(maxWeekText);
+      final int dashboardUpcomingCount =
+          SettingsModel.parseDashboardUpcomingCountText(
+        dashboardUpcomingCountText,
+      );
       SettingsModel.validateMaxWeek(maxWeek);
       SettingsModel.validateTimeSlotRanges(editedTimeSlotRanges);
+      SettingsModel.validateDashboardUpcomingCount(dashboardUpcomingCount);
       final SettingsData next = SettingsData(
         maxWeek: maxWeek,
         timeSlotRanges: List<TimePeriodRangeData>.unmodifiable(
           editedTimeSlotRanges,
         ),
+        dashboardUpcomingMode: dashboardUpcomingMode,
+        dashboardUpcomingCount: dashboardUpcomingCount,
       );
       await SettingsRepository.getInstance().saveSettings(next);
       _settingsData = next;
@@ -127,6 +140,8 @@ class SettingsViewModel extends BaseViewModel {
         context: <String, Object?>{
           'maxWeek': maxWeek,
           'timeSlotCount': editedTimeSlotRanges.length,
+          'dashboardUpcomingMode': dashboardUpcomingMode.jsonValue,
+          'dashboardUpcomingCount': dashboardUpcomingCount,
         },
       );
       notifyListeners();

--- a/lib/features/settings/view_models/settings_view_model.dart
+++ b/lib/features/settings/view_models/settings_view_model.dart
@@ -119,10 +119,10 @@ class SettingsViewModel extends BaseViewModel {
       final int maxWeek = SettingsModel.parseMaxWeekText(maxWeekText);
       final int dashboardUpcomingCount =
           dashboardUpcomingMode == DashboardUpcomingMode.count
-          ? SettingsModel.parseDashboardUpcomingCountText(
-              dashboardUpcomingCountText,
-            )
-          : _settingsData.dashboardUpcomingCount;
+              ? SettingsModel.parseDashboardUpcomingCountText(
+                  dashboardUpcomingCountText,
+                )
+              : _settingsData.dashboardUpcomingCount;
       SettingsModel.validateMaxWeek(maxWeek);
       SettingsModel.validateTimeSlotRanges(editedTimeSlotRanges);
       SettingsModel.validateDashboardUpcomingCount(dashboardUpcomingCount);

--- a/lib/features/settings/views/settings_view.dart
+++ b/lib/features/settings/views/settings_view.dart
@@ -1,4 +1,4 @@
-﻿import 'dart:async';
+import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/lib/features/settings/views/settings_view.dart
+++ b/lib/features/settings/views/settings_view.dart
@@ -9,6 +9,8 @@ import 'package:onetj/app/exception/app_exception.dart';
 import 'package:onetj/app/constant/route_paths.dart';
 import 'package:onetj/features/settings/models/event.dart';
 import 'package:onetj/features/settings/view_models/settings_view_model.dart';
+import 'package:onetj/models/dashboard_upcoming_mode.dart';
+import 'package:onetj/models/settings_defaults.dart';
 import 'package:onetj/models/event_model.dart';
 import 'package:onetj/models/time_period_range.dart';
 import 'package:onetj/models/time_slot.dart';
@@ -25,13 +27,16 @@ class _SettingsViewState extends State<SettingsView> {
   late final SettingsViewModel _viewModel;
   StreamSubscription<UiEvent>? _eventSub;
   late final TextEditingController _maxWeekController;
+  late final TextEditingController _dashboardCountController;
   List<TimePeriodRangeData> _draftTimeSlotRanges = <TimePeriodRangeData>[];
+  DashboardUpcomingMode _draftUpcomingMode = kDefaultDashboardUpcomingMode;
 
   @override
   void initState() {
     super.initState();
     _viewModel = SettingsViewModel();
     _maxWeekController = TextEditingController();
+    _dashboardCountController = TextEditingController();
     _eventSub = _viewModel.events.listen((event) {
       if (!mounted) {
         return;
@@ -70,6 +75,7 @@ class _SettingsViewState extends State<SettingsView> {
   void dispose() {
     _eventSub?.cancel();
     _maxWeekController.dispose();
+    _dashboardCountController.dispose();
     _viewModel.dispose();
     super.dispose();
   }
@@ -79,6 +85,8 @@ class _SettingsViewState extends State<SettingsView> {
     ShowSnackBarEvent event,
   ) {
     switch (event.code) {
+      case SettingsValidationException.maxWeekInvalidFormat:
+        return l10n.settingsMaxWeekInvalidFormat;
       case SettingsValidationException.maxWeekOutOfRange:
         return l10n.settingsMaxWeekInvalidRange;
       case SettingsValidationException.timeSlotEmpty:
@@ -93,6 +101,10 @@ class _SettingsViewState extends State<SettingsView> {
         return l10n.settingsTimeSlotsInvalidOrder;
       case SettingsValidationException.timeSlotOverlap:
         return l10n.settingsTimeSlotsInvalidOverlap;
+      case SettingsValidationException.dashboardUpcomingCountInvalidFormat:
+        return l10n.settingsDashboardUpcomingCountInvalidFormat;
+      case SettingsValidationException.dashboardUpcomingCountOutOfRange:
+        return l10n.settingsDashboardUpcomingCountInvalidRange;
       default:
         return event.message ?? '';
     }
@@ -106,17 +118,9 @@ class _SettingsViewState extends State<SettingsView> {
     _applySettingsToControllers(_viewModel.settingsData);
   }
 
-  void _submitMaxWeek() {
-    final int? value = int.tryParse(_maxWeekController.text);
-    if (value == null || value <= 0) {
-      // TODO: 提示用户输入合法的最大周数
-      return;
-    }
-    _submitSettings();
-  }
-
   void _applySettingsToControllers(SettingsData settings) {
     _maxWeekController.text = settings.maxWeek.toString();
+    _dashboardCountController.text = settings.dashboardUpcomingCount.toString();
     final List<TimePeriodRangeData> nextRanges = settings.timeSlotRanges
         .map(
           (item) => TimePeriodRangeData(
@@ -128,17 +132,20 @@ class _SettingsViewState extends State<SettingsView> {
     if (mounted) {
       setState(() {
         _draftTimeSlotRanges = nextRanges;
+        _draftUpcomingMode = settings.dashboardUpcomingMode;
       });
       return;
     }
     _draftTimeSlotRanges = nextRanges;
+    _draftUpcomingMode = settings.dashboardUpcomingMode;
   }
 
   Future<void> _submitSettings() async {
-    final int maxWeek = int.parse(_maxWeekController.text);
     await _viewModel.saveSettings(
-      maxWeek: maxWeek,
+      maxWeekText: _maxWeekController.text,
       editedTimeSlotRanges: _draftTimeSlotRanges,
+      dashboardUpcomingMode: _draftUpcomingMode,
+      dashboardUpcomingCountText: _dashboardCountController.text,
     );
   }
 
@@ -228,6 +235,19 @@ class _SettingsViewState extends State<SettingsView> {
     );
   }
 
+  String _dashboardUpcomingSummary(AppLocalizations l10n) {
+    switch (_draftUpcomingMode) {
+      case DashboardUpcomingMode.thisWeek:
+        return l10n.settingsDashboardUpcomingModeThisWeek;
+      case DashboardUpcomingMode.today:
+        return l10n.settingsDashboardUpcomingModeToday;
+      case DashboardUpcomingMode.count:
+        final int count = int.tryParse(_dashboardCountController.text) ??
+            kDefaultDashboardUpcomingCount;
+        return l10n.settingsDashboardUpcomingModeCountSummary(count);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -241,7 +261,7 @@ class _SettingsViewState extends State<SettingsView> {
               icon: const Icon(Icons.save),
               onPressed: _viewModel.settingsLoading || _viewModel.settingsSaving
                   ? null
-                  : _submitMaxWeek,
+                  : _submitSettings,
             ),
           ),
         ],
@@ -270,7 +290,6 @@ class _SettingsViewState extends State<SettingsView> {
                       isDense: true,
                       border: OutlineInputBorder(),
                     ),
-                    onSubmitted: (_) => _submitMaxWeek(),
                   ),
                 ),
               ),
@@ -286,6 +305,108 @@ class _SettingsViewState extends State<SettingsView> {
                 onTap: _viewModel.settingsLoading || _viewModel.settingsSaving
                     ? null
                     : _openTimeSlotEditor,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      AppLocalizations.of(context)
+                          .settingsDashboardUpcomingTitle,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      _dashboardUpcomingSummary(AppLocalizations.of(context)),
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 8),
+                    RadioListTile<DashboardUpcomingMode>(
+                      contentPadding: EdgeInsets.zero,
+                      value: DashboardUpcomingMode.thisWeek,
+                      groupValue: _draftUpcomingMode,
+                      onChanged: _viewModel.settingsLoading ||
+                              _viewModel.settingsSaving
+                          ? null
+                          : (value) {
+                              if (value == null) {
+                                return;
+                              }
+                              setState(() {
+                                _draftUpcomingMode = value;
+                              });
+                            },
+                      title: Text(
+                        AppLocalizations.of(context)
+                            .settingsDashboardUpcomingModeThisWeek,
+                      ),
+                    ),
+                    RadioListTile<DashboardUpcomingMode>(
+                      contentPadding: EdgeInsets.zero,
+                      value: DashboardUpcomingMode.today,
+                      groupValue: _draftUpcomingMode,
+                      onChanged: _viewModel.settingsLoading ||
+                              _viewModel.settingsSaving
+                          ? null
+                          : (value) {
+                              if (value == null) {
+                                return;
+                              }
+                              setState(() {
+                                _draftUpcomingMode = value;
+                              });
+                            },
+                      title: Text(
+                        AppLocalizations.of(context)
+                            .settingsDashboardUpcomingModeToday,
+                      ),
+                    ),
+                    RadioListTile<DashboardUpcomingMode>(
+                      contentPadding: EdgeInsets.zero,
+                      value: DashboardUpcomingMode.count,
+                      groupValue: _draftUpcomingMode,
+                      onChanged: _viewModel.settingsLoading ||
+                              _viewModel.settingsSaving
+                          ? null
+                          : (value) {
+                              if (value == null) {
+                                return;
+                              }
+                              setState(() {
+                                _draftUpcomingMode = value;
+                              });
+                            },
+                      title: Text(
+                        AppLocalizations.of(context)
+                            .settingsDashboardUpcomingModeCount,
+                      ),
+                    ),
+                    if (_draftUpcomingMode == DashboardUpcomingMode.count) ...[
+                      const SizedBox(height: 8),
+                      TextField(
+                        controller: _dashboardCountController,
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.digitsOnly,
+                        ],
+                        enabled: !_viewModel.settingsLoading &&
+                            !_viewModel.settingsSaving,
+                        decoration: InputDecoration(
+                          isDense: true,
+                          border: const OutlineInputBorder(),
+                          labelText: AppLocalizations.of(context)
+                              .settingsDashboardUpcomingCountLabel,
+                          helperText: AppLocalizations.of(context)
+                              .settingsDashboardUpcomingCountHint,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
               ),
             ),
             const SizedBox(height: 24),

--- a/lib/features/settings/views/settings_view.dart
+++ b/lib/features/settings/views/settings_view.dart
@@ -258,6 +258,13 @@ class _SettingsViewState extends State<SettingsView> {
     });
   }
 
+  void _onDashboardCountChanged(String _) {
+    if (_draftUpcomingMode != DashboardUpcomingMode.count) {
+      return;
+    }
+    setState(() {});
+  }
+
   Widget _buildMaxWeekCard(AppLocalizations l10n) {
     return Card(
       child: ListTile(
@@ -302,6 +309,7 @@ class _SettingsViewState extends State<SettingsView> {
       enabled: !_settingsBusy,
       summaryText: _dashboardUpcomingSummary(l10n),
       onModeChanged: _onUpcomingModeChanged,
+      onCountChanged: _onDashboardCountChanged,
     );
   }
 

--- a/lib/features/settings/views/settings_view.dart
+++ b/lib/features/settings/views/settings_view.dart
@@ -1,4 +1,4 @@
-import 'dart:async';
+﻿import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -9,6 +9,7 @@ import 'package:onetj/app/exception/app_exception.dart';
 import 'package:onetj/app/constant/route_paths.dart';
 import 'package:onetj/features/settings/models/event.dart';
 import 'package:onetj/features/settings/view_models/settings_view_model.dart';
+import 'package:onetj/features/settings/views/widgets/upcoming_courses_card.dart';
 import 'package:onetj/models/dashboard_upcoming_mode.dart';
 import 'package:onetj/models/settings_defaults.dart';
 import 'package:onetj/models/event_model.dart';
@@ -251,10 +252,7 @@ class _SettingsViewState extends State<SettingsView> {
   bool get _settingsBusy =>
       _viewModel.settingsLoading || _viewModel.settingsSaving;
 
-  void _onUpcomingModeChanged(DashboardUpcomingMode? value) {
-    if (value == null) {
-      return;
-    }
+  void _onUpcomingModeChanged(DashboardUpcomingMode value) {
     setState(() {
       _draftUpcomingMode = value;
     });
@@ -296,72 +294,14 @@ class _SettingsViewState extends State<SettingsView> {
     );
   }
 
-  Widget _buildUpcomingModeOption({
-    required DashboardUpcomingMode value,
-    required String title,
-  }) {
-    return RadioListTile<DashboardUpcomingMode>(
-      contentPadding: EdgeInsets.zero,
-      value: value,
-      groupValue: _draftUpcomingMode,
-      onChanged: _settingsBusy ? null : _onUpcomingModeChanged,
-      title: Text(title),
-    );
-  }
-
-  Widget _buildDashboardCountField(AppLocalizations l10n) {
-    return TextField(
-      controller: _dashboardCountController,
-      keyboardType: TextInputType.number,
-      inputFormatters: [
-        FilteringTextInputFormatter.digitsOnly,
-      ],
-      enabled: !_settingsBusy,
-      decoration: InputDecoration(
-        isDense: true,
-        border: const OutlineInputBorder(),
-        labelText: l10n.settingsDashboardUpcomingCountLabel,
-        helperText: l10n.settingsDashboardUpcomingCountHint,
-      ),
-    );
-  }
-
   Widget _buildDashboardUpcomingCard(AppLocalizations l10n) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              l10n.settingsDashboardUpcomingTitle,
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            const SizedBox(height: 4),
-            Text(
-              _dashboardUpcomingSummary(l10n),
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            const SizedBox(height: 8),
-            _buildUpcomingModeOption(
-              value: DashboardUpcomingMode.thisWeek,
-              title: l10n.settingsDashboardUpcomingModeThisWeek,
-            ),
-            _buildUpcomingModeOption(
-              value: DashboardUpcomingMode.today,
-              title: l10n.settingsDashboardUpcomingModeToday,
-            ),
-            _buildUpcomingModeOption(
-              value: DashboardUpcomingMode.count,
-              title: l10n.settingsDashboardUpcomingModeCount,
-            ),
-            if (_draftUpcomingMode == DashboardUpcomingMode.count) ...[
-              const SizedBox(height: 8),
-              _buildDashboardCountField(l10n),
-            ],
-          ],
-        ),
-      ),
+    return UpcomingCoursesCard(
+      l10n: l10n,
+      mode: _draftUpcomingMode,
+      countController: _dashboardCountController,
+      enabled: !_settingsBusy,
+      summaryText: _dashboardUpcomingSummary(l10n),
+      onModeChanged: _onUpcomingModeChanged,
     );
   }
 

--- a/lib/features/settings/views/settings_view.dart
+++ b/lib/features/settings/views/settings_view.dart
@@ -248,20 +248,175 @@ class _SettingsViewState extends State<SettingsView> {
     }
   }
 
+  bool get _settingsBusy =>
+      _viewModel.settingsLoading || _viewModel.settingsSaving;
+
+  void _onUpcomingModeChanged(DashboardUpcomingMode? value) {
+    if (value == null) {
+      return;
+    }
+    setState(() {
+      _draftUpcomingMode = value;
+    });
+  }
+
+  Widget _buildMaxWeekCard(AppLocalizations l10n) {
+    return Card(
+      child: ListTile(
+        title: Text(l10n.settingsMaxWeekTitle),
+        subtitle: Text(l10n.settingsMaxWeekSubtitle),
+        trailing: SizedBox(
+          width: 100,
+          child: TextField(
+            controller: _maxWeekController,
+            keyboardType: TextInputType.number,
+            inputFormatters: [
+              FilteringTextInputFormatter.digitsOnly,
+            ],
+            enabled: !_settingsBusy,
+            decoration: const InputDecoration(
+              isDense: true,
+              border: OutlineInputBorder(),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTimeSlotCard(AppLocalizations l10n) {
+    return Card(
+      child: ListTile(
+        leading: const Icon(Icons.schedule),
+        title: Text(l10n.settingsTimeSlotsTitle),
+        subtitle: Text(_timeSlotSummary(l10n)),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: _settingsBusy ? null : _openTimeSlotEditor,
+      ),
+    );
+  }
+
+  Widget _buildUpcomingModeOption({
+    required DashboardUpcomingMode value,
+    required String title,
+  }) {
+    return RadioListTile<DashboardUpcomingMode>(
+      contentPadding: EdgeInsets.zero,
+      value: value,
+      groupValue: _draftUpcomingMode,
+      onChanged: _settingsBusy ? null : _onUpcomingModeChanged,
+      title: Text(title),
+    );
+  }
+
+  Widget _buildDashboardCountField(AppLocalizations l10n) {
+    return TextField(
+      controller: _dashboardCountController,
+      keyboardType: TextInputType.number,
+      inputFormatters: [
+        FilteringTextInputFormatter.digitsOnly,
+      ],
+      enabled: !_settingsBusy,
+      decoration: InputDecoration(
+        isDense: true,
+        border: const OutlineInputBorder(),
+        labelText: l10n.settingsDashboardUpcomingCountLabel,
+        helperText: l10n.settingsDashboardUpcomingCountHint,
+      ),
+    );
+  }
+
+  Widget _buildDashboardUpcomingCard(AppLocalizations l10n) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.settingsDashboardUpcomingTitle,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              _dashboardUpcomingSummary(l10n),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            _buildUpcomingModeOption(
+              value: DashboardUpcomingMode.thisWeek,
+              title: l10n.settingsDashboardUpcomingModeThisWeek,
+            ),
+            _buildUpcomingModeOption(
+              value: DashboardUpcomingMode.today,
+              title: l10n.settingsDashboardUpcomingModeToday,
+            ),
+            _buildUpcomingModeOption(
+              value: DashboardUpcomingMode.count,
+              title: l10n.settingsDashboardUpcomingModeCount,
+            ),
+            if (_draftUpcomingMode == DashboardUpcomingMode.count) ...[
+              const SizedBox(height: 8),
+              _buildDashboardCountField(l10n),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAdvancedSectionTitle(AppLocalizations l10n) {
+    return Text(
+      l10n.settingsAdvancedSectionTitle,
+      style: Theme.of(context).textTheme.titleMedium,
+    );
+  }
+
+  Widget _buildResetCard(AppLocalizations l10n) {
+    return Card(
+      child: ListTile(
+        leading: const Icon(Icons.restore),
+        title: Text(l10n.settingsResetTitle),
+        subtitle: Text(l10n.settingsResetSubtitle),
+        onTap: _settingsBusy ? null : () => _confirmResetSettings(context),
+      ),
+    );
+  }
+
+  Widget _buildDeveloperCard(AppLocalizations l10n) {
+    return Card(
+      child: ListTile(
+        leading: const Icon(Icons.developer_mode),
+        title: Text(l10n.settingsDeveloperTitle),
+        subtitle: Text(l10n.settingsDeveloperSubtitle),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: () => context.push(RoutePaths.homeSettingsDeveloper),
+      ),
+    );
+  }
+
+  Widget _buildLogoutButton(AppLocalizations l10n) {
+    return Center(
+      child: FilledButton(
+        onPressed: _viewModel.loading ? null : () => _logout(context),
+        child: Text(l10n.logOut),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: Text(AppLocalizations.of(context).tabSettings),
+        title: Text(l10n.tabSettings),
         actions: [
           AnimatedBuilder(
             animation: _viewModel,
             builder: (context, _) => IconButton(
-              tooltip: AppLocalizations.of(context).saveLabel,
+              tooltip: l10n.saveLabel,
               icon: const Icon(Icons.save),
-              onPressed: _viewModel.settingsLoading || _viewModel.settingsSaving
-                  ? null
-                  : _submitSettings,
+              onPressed: _settingsBusy ? null : _submitSettings,
             ),
           ),
         ],
@@ -271,181 +426,19 @@ class _SettingsViewState extends State<SettingsView> {
         builder: (context, _) => ListView(
           padding: const EdgeInsets.all(16),
           children: [
-            Card(
-              child: ListTile(
-                title: Text(AppLocalizations.of(context).settingsMaxWeekTitle),
-                subtitle:
-                    Text(AppLocalizations.of(context).settingsMaxWeekSubtitle),
-                trailing: SizedBox(
-                  width: 100,
-                  child: TextField(
-                    controller: _maxWeekController,
-                    keyboardType: TextInputType.number,
-                    inputFormatters: [
-                      FilteringTextInputFormatter.digitsOnly,
-                    ],
-                    enabled: !_viewModel.settingsLoading &&
-                        !_viewModel.settingsSaving,
-                    decoration: const InputDecoration(
-                      isDense: true,
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                ),
-              ),
-            ),
+            _buildMaxWeekCard(l10n),
             const SizedBox(height: 12),
-            Card(
-              child: ListTile(
-                leading: const Icon(Icons.schedule),
-                title:
-                    Text(AppLocalizations.of(context).settingsTimeSlotsTitle),
-                subtitle: Text(_timeSlotSummary(AppLocalizations.of(context))),
-                trailing: const Icon(Icons.chevron_right),
-                onTap: _viewModel.settingsLoading || _viewModel.settingsSaving
-                    ? null
-                    : _openTimeSlotEditor,
-              ),
-            ),
+            _buildTimeSlotCard(l10n),
             const SizedBox(height: 12),
-            Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      AppLocalizations.of(context)
-                          .settingsDashboardUpcomingTitle,
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      _dashboardUpcomingSummary(AppLocalizations.of(context)),
-                      style: Theme.of(context).textTheme.bodySmall,
-                    ),
-                    const SizedBox(height: 8),
-                    RadioListTile<DashboardUpcomingMode>(
-                      contentPadding: EdgeInsets.zero,
-                      value: DashboardUpcomingMode.thisWeek,
-                      groupValue: _draftUpcomingMode,
-                      onChanged: _viewModel.settingsLoading ||
-                              _viewModel.settingsSaving
-                          ? null
-                          : (value) {
-                              if (value == null) {
-                                return;
-                              }
-                              setState(() {
-                                _draftUpcomingMode = value;
-                              });
-                            },
-                      title: Text(
-                        AppLocalizations.of(context)
-                            .settingsDashboardUpcomingModeThisWeek,
-                      ),
-                    ),
-                    RadioListTile<DashboardUpcomingMode>(
-                      contentPadding: EdgeInsets.zero,
-                      value: DashboardUpcomingMode.today,
-                      groupValue: _draftUpcomingMode,
-                      onChanged: _viewModel.settingsLoading ||
-                              _viewModel.settingsSaving
-                          ? null
-                          : (value) {
-                              if (value == null) {
-                                return;
-                              }
-                              setState(() {
-                                _draftUpcomingMode = value;
-                              });
-                            },
-                      title: Text(
-                        AppLocalizations.of(context)
-                            .settingsDashboardUpcomingModeToday,
-                      ),
-                    ),
-                    RadioListTile<DashboardUpcomingMode>(
-                      contentPadding: EdgeInsets.zero,
-                      value: DashboardUpcomingMode.count,
-                      groupValue: _draftUpcomingMode,
-                      onChanged: _viewModel.settingsLoading ||
-                              _viewModel.settingsSaving
-                          ? null
-                          : (value) {
-                              if (value == null) {
-                                return;
-                              }
-                              setState(() {
-                                _draftUpcomingMode = value;
-                              });
-                            },
-                      title: Text(
-                        AppLocalizations.of(context)
-                            .settingsDashboardUpcomingModeCount,
-                      ),
-                    ),
-                    if (_draftUpcomingMode == DashboardUpcomingMode.count) ...[
-                      const SizedBox(height: 8),
-                      TextField(
-                        controller: _dashboardCountController,
-                        keyboardType: TextInputType.number,
-                        inputFormatters: [
-                          FilteringTextInputFormatter.digitsOnly,
-                        ],
-                        enabled: !_viewModel.settingsLoading &&
-                            !_viewModel.settingsSaving,
-                        decoration: InputDecoration(
-                          isDense: true,
-                          border: const OutlineInputBorder(),
-                          labelText: AppLocalizations.of(context)
-                              .settingsDashboardUpcomingCountLabel,
-                          helperText: AppLocalizations.of(context)
-                              .settingsDashboardUpcomingCountHint,
-                        ),
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-            ),
+            _buildDashboardUpcomingCard(l10n),
             const SizedBox(height: 24),
-            Text(
-              AppLocalizations.of(context).settingsAdvancedSectionTitle,
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
+            _buildAdvancedSectionTitle(l10n),
             const SizedBox(height: 8),
-            Card(
-              child: ListTile(
-                leading: const Icon(Icons.restore),
-                title: Text(AppLocalizations.of(context).settingsResetTitle),
-                subtitle:
-                    Text(AppLocalizations.of(context).settingsResetSubtitle),
-                onTap: _viewModel.settingsLoading || _viewModel.settingsSaving
-                    ? null
-                    : () => _confirmResetSettings(context),
-              ),
-            ),
+            _buildResetCard(l10n),
             const SizedBox(height: 12),
-            Card(
-              child: ListTile(
-                leading: const Icon(Icons.developer_mode),
-                title:
-                    Text(AppLocalizations.of(context).settingsDeveloperTitle),
-                subtitle: Text(
-                  AppLocalizations.of(context).settingsDeveloperSubtitle,
-                ),
-                trailing: const Icon(Icons.chevron_right),
-                onTap: () => context.push(RoutePaths.homeSettingsDeveloper),
-              ),
-            ),
+            _buildDeveloperCard(l10n),
             const SizedBox(height: 24),
-            Center(
-              child: FilledButton(
-                onPressed: _viewModel.loading ? null : () => _logout(context),
-                child: Text(AppLocalizations.of(context).logOut),
-              ),
-            ),
+            _buildLogoutButton(l10n),
           ],
         ),
       ),

--- a/lib/features/settings/views/widgets/upcoming_courses_card.dart
+++ b/lib/features/settings/views/widgets/upcoming_courses_card.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'package:onetj/models/dashboard_upcoming_mode.dart';
+
+class UpcomingCoursesCard extends StatefulWidget {
+  const UpcomingCoursesCard({
+    required this.l10n,
+    required this.mode,
+    required this.countController,
+    required this.enabled,
+    required this.summaryText,
+    required this.onModeChanged,
+    super.key,
+  });
+
+  final AppLocalizations l10n;
+  final DashboardUpcomingMode mode;
+  final TextEditingController countController;
+  final bool enabled;
+  final String summaryText;
+  final ValueChanged<DashboardUpcomingMode> onModeChanged;
+
+  @override
+  State<UpcomingCoursesCard> createState() => _UpcomingCoursesCardState();
+}
+
+class _UpcomingCoursesCardState extends State<UpcomingCoursesCard>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _expandController;
+  late final Animation<double> _expandAnimation;
+  bool _expanded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _expandController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 180),
+    );
+    _expandAnimation = CurvedAnimation(
+      parent: _expandController,
+      curve: Curves.easeInOut,
+    );
+  }
+
+  @override
+  void dispose() {
+    _expandController.dispose();
+    super.dispose();
+  }
+
+  void _toggleExpanded() {
+    setState(() {
+      _expanded = !_expanded;
+    });
+    if (_expanded) {
+      _expandController.forward();
+      return;
+    }
+    _expandController.reverse();
+  }
+
+  void _onModeChanged(DashboardUpcomingMode? value) {
+    if (value == null) {
+      return;
+    }
+    widget.onModeChanged(value);
+  }
+
+  Widget _buildModeOption({
+    required DashboardUpcomingMode value,
+    required String title,
+  }) {
+    return RadioListTile<DashboardUpcomingMode>(
+      contentPadding: EdgeInsets.zero,
+      value: value,
+      groupValue: widget.mode,
+      onChanged: widget.enabled ? _onModeChanged : null,
+      title: Text(title),
+    );
+  }
+
+  Widget _buildCountField() {
+    return TextField(
+      controller: widget.countController,
+      keyboardType: TextInputType.number,
+      inputFormatters: [
+        FilteringTextInputFormatter.digitsOnly,
+      ],
+      enabled: widget.enabled,
+      decoration: InputDecoration(
+        isDense: true,
+        border: const OutlineInputBorder(),
+        labelText: widget.l10n.settingsDashboardUpcomingCountLabel,
+        helperText: widget.l10n.settingsDashboardUpcomingCountHint,
+      ),
+    );
+  }
+
+  Widget _buildExpandedContent() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 8),
+          _buildModeOption(
+            value: DashboardUpcomingMode.thisWeek,
+            title: widget.l10n.settingsDashboardUpcomingModeThisWeek,
+          ),
+          _buildModeOption(
+            value: DashboardUpcomingMode.today,
+            title: widget.l10n.settingsDashboardUpcomingModeToday,
+          ),
+          _buildModeOption(
+            value: DashboardUpcomingMode.count,
+            title: widget.l10n.settingsDashboardUpcomingModeCount,
+          ),
+          _CountFieldSection(
+            visible: widget.mode == DashboardUpcomingMode.count,
+            child: _buildCountField(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            title: Text(widget.l10n.settingsDashboardUpcomingTitle),
+            subtitle: Text(widget.summaryText),
+            trailing: AnimatedRotation(
+              turns: _expanded ? 0.5 : 0,
+              duration: const Duration(milliseconds: 180),
+              curve: Curves.easeInOut,
+              child: const Icon(Icons.expand_more),
+            ),
+            onTap: _toggleExpanded,
+          ),
+          SizeTransition(
+            sizeFactor: _expandAnimation,
+            axisAlignment: -1.0,
+            child: _buildExpandedContent(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CountFieldSection extends StatefulWidget {
+  const _CountFieldSection({
+    required this.visible,
+    required this.child,
+  });
+
+  final bool visible;
+  final Widget child;
+
+  @override
+  State<_CountFieldSection> createState() => _CountFieldSectionState();
+}
+
+class _CountFieldSectionState extends State<_CountFieldSection>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 180),
+      value: widget.visible ? 1 : 0,
+    );
+    _animation = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOut,
+      reverseCurve: Curves.easeIn,
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant _CountFieldSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.visible == oldWidget.visible) {
+      return;
+    }
+    if (widget.visible) {
+      _controller.forward();
+      return;
+    }
+    _controller.reverse();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      ignoring: !widget.visible,
+      child: SizeTransition(
+        sizeFactor: _animation,
+        axisAlignment: -1.0,
+        child: Padding(
+          padding: const EdgeInsets.only(top: 8),
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/views/widgets/upcoming_courses_card.dart
+++ b/lib/features/settings/views/widgets/upcoming_courses_card.dart
@@ -12,6 +12,7 @@ class UpcomingCoursesCard extends StatefulWidget {
     required this.enabled,
     required this.summaryText,
     required this.onModeChanged,
+    required this.onCountChanged,
     super.key,
   });
 
@@ -21,6 +22,7 @@ class UpcomingCoursesCard extends StatefulWidget {
   final bool enabled;
   final String summaryText;
   final ValueChanged<DashboardUpcomingMode> onModeChanged;
+  final ValueChanged<String> onCountChanged;
 
   @override
   State<UpcomingCoursesCard> createState() => _UpcomingCoursesCardState();
@@ -85,6 +87,7 @@ class _UpcomingCoursesCardState extends State<UpcomingCoursesCard>
   Widget _buildCountField() {
     return TextField(
       controller: widget.countController,
+      onChanged: widget.onCountChanged,
       keyboardType: TextInputType.number,
       inputFormatters: [
         FilteringTextInputFormatter.digitsOnly,

--- a/lib/features/timetable/views/timetable_view.dart
+++ b/lib/features/timetable/views/timetable_view.dart
@@ -4,12 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:onetj/features/timetable/view_models/timetable_view_model.dart';
-import 'package:onetj/features/timetable/views/widgets/timeline_content.dart';
+import 'package:onetj/features/timetable/views/widgets/timetable_timeline_panel.dart';
 import 'package:onetj/features/timetable/models/event.dart';
 import 'package:onetj/models/event_model.dart';
-import 'package:onetj/models/time_period_range.dart';
 import 'package:onetj/models/timetable_index.dart';
-import 'package:onetj/models/time_slot.dart';
 
 class TimetableView extends StatefulWidget {
   const TimetableView({super.key});
@@ -171,12 +169,17 @@ class _TimetableViewState extends State<TimetableView> {
           duration: animationDuration,
         ),
         Expanded(
-          child: _buildTimetableView(
-            context,
+          child: TimetableTimelinePanel(
             mode: _viewModel.mode,
             dayLabels: dayLabels,
+            timeSlotRanges: _viewModel.timeSlotRanges,
+            selectedDay: _viewModel.selectedDay,
             duration: animationDuration,
             disableAnimations: disableAnimations,
+            scrollController: _scrollController,
+            roomBuilder: _formatRoom,
+            teacherBuilder: _formatTeacher,
+            entriesForDay: _viewModel.entriesForSelectedWeekDay,
           ),
         ),
       ],
@@ -212,183 +215,6 @@ class _TimetableViewState extends State<TimetableView> {
       }
       // TODO 日志记录未同步的情况
     });
-  }
-
-  double _weekHeaderHeight(BuildContext context) {
-    final TextStyle style =
-        Theme.of(context).textTheme.bodySmall ?? const TextStyle();
-    final String dayLabel = AppLocalizations.of(context).weekdayMon;
-    const double padding = 8;
-    final TextPainter painter = TextPainter(
-      text: TextSpan(text: dayLabel, style: style),
-      maxLines: 1,
-      textDirection: TextDirection.ltr,
-    )..layout();
-    return painter.height + padding;
-  }
-
-  Widget _buildTimetableView(
-    BuildContext context, {
-    required TimetableDisplayMode mode,
-    required List<String> dayLabels,
-    required Duration duration,
-    required bool disableAnimations,
-  }) {
-    const double slotHeight = 64;
-    const double preferredLabelWidth = 72;
-    const double minLabelWidth = 35;
-    final List<_TimeSlot> timeSlots = _buildTimeSlots(_viewModel.timeSlotRanges);
-    final double targetHeaderHeight =
-        mode == TimetableDisplayMode.week ? _weekHeaderHeight(context) : 0;
-
-    return TweenAnimationBuilder<double>(
-      duration: duration,
-      curve: mode == TimetableDisplayMode.week
-          ? Curves.easeOutCubic
-          : Curves.easeInCubic,
-      tween: Tween<double>(begin: 0, end: targetHeaderHeight),
-      builder: (context, animatedHeaderHeight, _) {
-        final double contentHeight =
-            timeSlots.length * slotHeight + animatedHeaderHeight;
-        return Padding(
-          padding: const EdgeInsets.fromLTRB(4, 8, 12, 4),
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              final double availableWidth =
-                  (constraints.maxWidth - 8).clamp(0, double.infinity);
-              final double minCardWidth = 92;
-              final double maxCardWidth = double.infinity;
-              double labelWidth = preferredLabelWidth;
-              double dayColumnWidth =
-                  ((availableWidth - labelWidth) / 7).clamp(0, maxCardWidth);
-
-              if (dayColumnWidth < minCardWidth) {
-                final double neededLabelWidth = availableWidth - minCardWidth * 7;
-                labelWidth =
-                    neededLabelWidth.clamp(minLabelWidth, preferredLabelWidth);
-                dayColumnWidth =
-                    ((availableWidth - labelWidth) / 7).clamp(0, maxCardWidth);
-              }
-              final bool isNarrowLabel = labelWidth <= minLabelWidth + 0.1;
-              final TextStyle? labelStyle = isNarrowLabel
-                  ? Theme.of(context).textTheme.bodySmall?.copyWith(fontSize: 11)
-                  : Theme.of(context).textTheme.bodySmall;
-
-              return SingleChildScrollView(
-                controller: _scrollController,
-                child: SizedBox(
-                  height: contentHeight,
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      SizedBox(
-                        width: labelWidth,
-                        child: Column(
-                          children: [
-                            SizedBox(height: animatedHeaderHeight),
-                            for (final slot in timeSlots)
-                              Container(
-                                height: slotHeight,
-                                alignment: Alignment.topCenter,
-                                padding: const EdgeInsets.only(top: 6),
-                                child: Text(
-                                  slot.label,
-                                  style: labelStyle,
-                                ),
-                              ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Stack(
-                          children: [
-                            Positioned.fill(
-                              child: Column(
-                                children: [
-                                  SizedBox(height: animatedHeaderHeight),
-                                  for (int i = 0; i < timeSlots.length; i += 1)
-                                    Container(
-                                      height: slotHeight,
-                                      decoration: BoxDecoration(
-                                        border: Border(
-                                          bottom: BorderSide(
-                                            color: Theme.of(context)
-                                                .colorScheme
-                                                .outlineVariant,
-                                          ),
-                                        ),
-                                      ),
-                                    ),
-                                ],
-                              ),
-                            ),
-                            Positioned.fill(
-                              child: AnimatedSwitcher(
-                                duration: duration,
-                                switchInCurve: Curves.easeOut,
-                                switchOutCurve: Curves.easeOut,
-                                transitionBuilder: (child, animation) {
-                                  if (disableAnimations) {
-                                    return child;
-                                  }
-                                  return FadeTransition(
-                                    opacity: animation,
-                                    child: child,
-                                  );
-                                },
-                                layoutBuilder: (currentChild, previousChildren) {
-                                  return Stack(
-                                    fit: StackFit.expand,
-                                    children: [
-                                      ...previousChildren,
-                                      if (currentChild != null) currentChild,
-                                    ],
-                                  );
-                                },
-                                child: mode == TimetableDisplayMode.day
-                                    ? KeyedSubtree(
-                                        key: const ValueKey<String>('day-content'),
-                                        child: DayTimelineContent(
-                                          entries:
-                                              _viewModel.entriesForSelectedWeekDay(
-                                            _viewModel.selectedDay,
-                                          ),
-                                          slotHeight: slotHeight,
-                                          slotCount: timeSlots.length,
-                                          roomBuilder: _formatRoom,
-                                          teacherBuilder: _formatTeacher,
-                                        ),
-                                      )
-                                    : KeyedSubtree(
-                                        key: const ValueKey<String>('week-content'),
-                                        child: WeekTimelineContent(
-                                          dayLabels: dayLabels,
-                                          dayColumnWidth: dayColumnWidth,
-                                          slotHeight: slotHeight,
-                                          slotCount: timeSlots.length,
-                                          entriesForDay: (day) =>
-                                              _viewModel.entriesForSelectedWeekDay(
-                                            day,
-                                          ),
-                                          roomBuilder: _formatRoom,
-                                          teacherBuilder: _formatTeacher,
-                                        ),
-                                      ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            },
-          ),
-        );
-      },
-    );
   }
 
   Widget _buildAnimatedDayWheel({
@@ -527,18 +353,6 @@ class _WheelItem extends StatelessWidget {
       ),
     );
   }
-}
-
-class _TimeSlot {
-  const _TimeSlot(this.label);
-
-  final String label;
-}
-
-List<_TimeSlot> _buildTimeSlots(List<TimePeriodRangeData> ranges) {
-  return ranges
-      .map((range) => _TimeSlot(TimeSlot.formatMinutes(range.startMinutes)))
-      .toList();
 }
 
 class _HorizontalWheel extends StatelessWidget {

--- a/lib/features/timetable/views/timetable_view.dart
+++ b/lib/features/timetable/views/timetable_view.dart
@@ -91,6 +91,11 @@ class _TimetableViewState extends State<TimetableView> {
 
   Widget _buildBody(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final bool disableAnimations =
+        MediaQuery.maybeOf(context)?.disableAnimations ?? false;
+    const Duration defaultDuration = Duration(milliseconds: 220);
+    final Duration animationDuration =
+        disableAnimations ? Duration.zero : defaultDuration;
     if (_viewModel.isLoading) {
       return const Center(child: CircularProgressIndicator());
     }
@@ -161,33 +166,17 @@ class _TimetableViewState extends State<TimetableView> {
               },
             ),
           ),
-        if (_viewModel.mode == TimetableDisplayMode.day)
-          SizedBox(
-            height: 40,
-            child: _HorizontalWheel(
-              controller: _dayController,
-              itemExtent: 64,
-              itemCount: dayLabels.length,
-              onSelectedItemChanged: (index) {
-                if (index < 0 || index >= dayLabels.length) {
-                  return;
-                }
-                _viewModel.selectDay(index + 1);
-              },
-              itemBuilder: (context, index) {
-                final bool selected = _viewModel.selectedDay == index + 1;
-                return _WheelItem(
-                  label: dayLabels[index],
-                  selected: selected,
-                );
-              },
-            ),
-          ),
+        _buildAnimatedDayWheel(
+          dayLabels: dayLabels,
+          duration: animationDuration,
+        ),
         Expanded(
           child: _buildTimetableView(
             context,
             mode: _viewModel.mode,
             dayLabels: dayLabels,
+            duration: animationDuration,
+            disableAnimations: disableAnimations,
           ),
         ),
       ],
@@ -242,122 +231,269 @@ class _TimetableViewState extends State<TimetableView> {
     BuildContext context, {
     required TimetableDisplayMode mode,
     required List<String> dayLabels,
+    required Duration duration,
+    required bool disableAnimations,
   }) {
     const double slotHeight = 64;
     const double preferredLabelWidth = 72;
     const double minLabelWidth = 35;
     final List<_TimeSlot> timeSlots = _buildTimeSlots(_viewModel.timeSlotRanges);
-    final double headerHeight =
+    final double targetHeaderHeight =
         mode == TimetableDisplayMode.week ? _weekHeaderHeight(context) : 0;
-    final double contentHeight = timeSlots.length * slotHeight + headerHeight;
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(4, 8, 12, 4),
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final double availableWidth =
-              (constraints.maxWidth - 8).clamp(0, double.infinity);
-          final double minCardWidth = 92;
-          final double maxCardWidth = double.infinity;
-          double labelWidth = preferredLabelWidth;
-          double dayColumnWidth =
-              ((availableWidth - labelWidth) / 7).clamp(0, maxCardWidth);
+    return TweenAnimationBuilder<double>(
+      duration: duration,
+      curve: mode == TimetableDisplayMode.week
+          ? Curves.easeOutCubic
+          : Curves.easeInCubic,
+      tween: Tween<double>(begin: 0, end: targetHeaderHeight),
+      builder: (context, animatedHeaderHeight, _) {
+        final double contentHeight =
+            timeSlots.length * slotHeight + animatedHeaderHeight;
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(4, 8, 12, 4),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final double availableWidth =
+                  (constraints.maxWidth - 8).clamp(0, double.infinity);
+              final double minCardWidth = 92;
+              final double maxCardWidth = double.infinity;
+              double labelWidth = preferredLabelWidth;
+              double dayColumnWidth =
+                  ((availableWidth - labelWidth) / 7).clamp(0, maxCardWidth);
 
-          if (dayColumnWidth < minCardWidth) {
-            final double neededLabelWidth = availableWidth - minCardWidth * 7;
-            labelWidth =
-                neededLabelWidth.clamp(minLabelWidth, preferredLabelWidth);
-            dayColumnWidth =
-                ((availableWidth - labelWidth) / 7).clamp(0, maxCardWidth);
-          }
-          final bool isNarrowLabel = labelWidth <= minLabelWidth + 0.1;
-          final TextStyle? labelStyle = isNarrowLabel
-              ? Theme.of(context).textTheme.bodySmall?.copyWith(fontSize: 11)
-              : Theme.of(context).textTheme.bodySmall;
+              if (dayColumnWidth < minCardWidth) {
+                final double neededLabelWidth = availableWidth - minCardWidth * 7;
+                labelWidth =
+                    neededLabelWidth.clamp(minLabelWidth, preferredLabelWidth);
+                dayColumnWidth =
+                    ((availableWidth - labelWidth) / 7).clamp(0, maxCardWidth);
+              }
+              final bool isNarrowLabel = labelWidth <= minLabelWidth + 0.1;
+              final TextStyle? labelStyle = isNarrowLabel
+                  ? Theme.of(context).textTheme.bodySmall?.copyWith(fontSize: 11)
+                  : Theme.of(context).textTheme.bodySmall;
 
-          return SingleChildScrollView(
-            controller: _scrollController,
-            child: SizedBox(
-              height: contentHeight,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  SizedBox(
-                    width: labelWidth,
-                    child: Column(
-                      children: [
-                        if (headerHeight > 0) SizedBox(height: headerHeight),
-                        for (final slot in timeSlots)
-                          Container(
-                            height: slotHeight,
-                            alignment: Alignment.topCenter,
-                            padding: const EdgeInsets.only(top: 6),
-                            child: Text(
-                              slot.label,
-                              style: labelStyle,
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Stack(
-                      children: [
-                        Positioned.fill(
-                          child: Column(
-                            children: [
-                              if (headerHeight > 0)
-                                SizedBox(height: headerHeight),
-                              for (int i = 0; i < timeSlots.length; i += 1)
-                                Container(
-                                  height: slotHeight,
-                                  decoration: BoxDecoration(
-                                    border: Border(
-                                      bottom: BorderSide(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .outlineVariant,
+              return SingleChildScrollView(
+                controller: _scrollController,
+                child: SizedBox(
+                  height: contentHeight,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SizedBox(
+                        width: labelWidth,
+                        child: Column(
+                          children: [
+                            SizedBox(height: animatedHeaderHeight),
+                            for (final slot in timeSlots)
+                              Container(
+                                height: slotHeight,
+                                alignment: Alignment.topCenter,
+                                padding: const EdgeInsets.only(top: 6),
+                                child: Text(
+                                  slot.label,
+                                  style: labelStyle,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Stack(
+                          children: [
+                            Positioned.fill(
+                              child: Column(
+                                children: [
+                                  SizedBox(height: animatedHeaderHeight),
+                                  for (int i = 0; i < timeSlots.length; i += 1)
+                                    Container(
+                                      height: slotHeight,
+                                      decoration: BoxDecoration(
+                                        border: Border(
+                                          bottom: BorderSide(
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .outlineVariant,
+                                          ),
+                                        ),
                                       ),
                                     ),
-                                  ),
-                                ),
-                            ],
-                          ),
-                        ),
-                        if (mode == TimetableDisplayMode.day)
-                          Positioned.fill(
-                            child: DayTimelineContent(
-                              entries: _viewModel.entriesForSelectedWeekDay(
-                                _viewModel.selectedDay,
+                                ],
                               ),
-                              slotHeight: slotHeight,
-                              slotCount: timeSlots.length,
-                              roomBuilder: _formatRoom,
-                              teacherBuilder: _formatTeacher,
                             ),
-                          )
-                        else if (mode == TimetableDisplayMode.week)
-                          Positioned.fill(
-                            child: WeekTimelineContent(
-                              dayLabels: dayLabels,
-                              dayColumnWidth: dayColumnWidth,
-                              slotHeight: slotHeight,
-                              slotCount: timeSlots.length,
-                              entriesForDay: (day) =>
-                                  _viewModel.entriesForSelectedWeekDay(day),
-                              roomBuilder: _formatRoom,
-                              teacherBuilder: _formatTeacher,
+                            Positioned.fill(
+                              child: AnimatedSwitcher(
+                                duration: duration,
+                                switchInCurve: Curves.easeOut,
+                                switchOutCurve: Curves.easeOut,
+                                transitionBuilder: (child, animation) {
+                                  if (disableAnimations) {
+                                    return child;
+                                  }
+                                  return FadeTransition(
+                                    opacity: animation,
+                                    child: child,
+                                  );
+                                },
+                                layoutBuilder: (currentChild, previousChildren) {
+                                  return Stack(
+                                    fit: StackFit.expand,
+                                    children: [
+                                      ...previousChildren,
+                                      if (currentChild != null) currentChild,
+                                    ],
+                                  );
+                                },
+                                child: mode == TimetableDisplayMode.day
+                                    ? KeyedSubtree(
+                                        key: const ValueKey<String>('day-content'),
+                                        child: DayTimelineContent(
+                                          entries:
+                                              _viewModel.entriesForSelectedWeekDay(
+                                            _viewModel.selectedDay,
+                                          ),
+                                          slotHeight: slotHeight,
+                                          slotCount: timeSlots.length,
+                                          roomBuilder: _formatRoom,
+                                          teacherBuilder: _formatTeacher,
+                                        ),
+                                      )
+                                    : KeyedSubtree(
+                                        key: const ValueKey<String>('week-content'),
+                                        child: WeekTimelineContent(
+                                          dayLabels: dayLabels,
+                                          dayColumnWidth: dayColumnWidth,
+                                          slotHeight: slotHeight,
+                                          slotCount: timeSlots.length,
+                                          entriesForDay: (day) =>
+                                              _viewModel.entriesForSelectedWeekDay(
+                                            day,
+                                          ),
+                                          roomBuilder: _formatRoom,
+                                          teacherBuilder: _formatTeacher,
+                                        ),
+                                      ),
+                              ),
                             ),
-                          ),
-                      ],
-                    ),
+                          ],
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-            ),
-          );
-        },
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildAnimatedDayWheel({
+    required List<String> dayLabels,
+    required Duration duration,
+  }) {
+    return _AnimatedDayWheel(
+      isExpanded: _viewModel.mode == TimetableDisplayMode.day,
+      duration: duration,
+      child: SizedBox(
+        height: 40,
+        child: _HorizontalWheel(
+          controller: _dayController,
+          itemExtent: 64,
+          itemCount: dayLabels.length,
+          onSelectedItemChanged: (index) {
+            if (index < 0 || index >= dayLabels.length) {
+              return;
+            }
+            _viewModel.selectDay(index + 1);
+          },
+          itemBuilder: (context, index) {
+            final bool selected = _viewModel.selectedDay == index + 1;
+            return _WheelItem(
+              label: dayLabels[index],
+              selected: selected,
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _AnimatedDayWheel extends StatefulWidget {
+  const _AnimatedDayWheel({
+    required this.isExpanded,
+    required this.duration,
+    required this.child,
+  });
+
+  final bool isExpanded;
+  final Duration duration;
+  final Widget child;
+
+  @override
+  State<_AnimatedDayWheel> createState() => _AnimatedDayWheelState();
+}
+
+class _AnimatedDayWheelState extends State<_AnimatedDayWheel>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _sizeFactor;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+      value: widget.isExpanded ? 1 : 0,
+    );
+    _sizeFactor = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOutCubic,
+      reverseCurve: Curves.easeInCubic,
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant _AnimatedDayWheel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _controller.duration = widget.duration;
+    if (oldWidget.isExpanded == widget.isExpanded &&
+        oldWidget.duration == widget.duration) {
+      return;
+    }
+    if (widget.duration == Duration.zero) {
+      _controller.value = widget.isExpanded ? 1 : 0;
+      return;
+    }
+    if (widget.isExpanded) {
+      _controller.forward();
+      return;
+    }
+    _controller.reverse();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRect(
+      child: SizeTransition(
+        sizeFactor: _sizeFactor,
+        axis: Axis.vertical,
+        axisAlignment: -1,
+        child: IgnorePointer(
+          ignoring: !widget.isExpanded,
+          child: widget.child,
+        ),
       ),
     );
   }

--- a/lib/features/timetable/views/widgets/timetable_timeline_panel.dart
+++ b/lib/features/timetable/views/widgets/timetable_timeline_panel.dart
@@ -1,0 +1,341 @@
+﻿import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'package:onetj/features/timetable/view_models/timetable_view_model.dart';
+import 'package:onetj/features/timetable/views/widgets/timeline_content.dart';
+import 'package:onetj/models/time_period_range.dart';
+import 'package:onetj/models/time_slot.dart';
+import 'package:onetj/models/timetable_index.dart';
+
+class TimetableTimelinePanel extends StatelessWidget {
+  const TimetableTimelinePanel({
+    required this.mode,
+    required this.dayLabels,
+    required this.timeSlotRanges,
+    required this.selectedDay,
+    required this.duration,
+    required this.disableAnimations,
+    required this.scrollController,
+    required this.roomBuilder,
+    required this.teacherBuilder,
+    required this.entriesForDay,
+    super.key,
+  });
+
+  final TimetableDisplayMode mode;
+  final List<String> dayLabels;
+  final List<TimePeriodRangeData> timeSlotRanges;
+  final int selectedDay;
+  final Duration duration;
+  final bool disableAnimations;
+  final ScrollController scrollController;
+  final String Function(TimetableEntry) roomBuilder;
+  final String Function(TimetableEntry) teacherBuilder;
+  final List<TimetableEntry> Function(int day) entriesForDay;
+
+  @override
+  Widget build(BuildContext context) {
+    const double slotHeight = 64;
+    final List<_TimeSlot> timeSlots = _buildTimeSlots(timeSlotRanges);
+    final double targetHeaderHeight =
+        mode == TimetableDisplayMode.week ? _weekHeaderHeight(context) : 0;
+
+    return TweenAnimationBuilder<double>(
+      duration: duration,
+      curve: mode == TimetableDisplayMode.week
+          ? Curves.easeOutCubic
+          : Curves.easeInCubic,
+      tween: Tween<double>(begin: 0, end: targetHeaderHeight),
+      builder: (context, animatedHeaderHeight, _) {
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(4, 8, 12, 4),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final _TimelineLayoutMetrics layoutMetrics = _computeTimelineMetrics(
+                context,
+                maxWidth: constraints.maxWidth,
+                timeSlotsCount: timeSlots.length,
+                slotHeight: slotHeight,
+                animatedHeaderHeight: animatedHeaderHeight,
+              );
+              return SingleChildScrollView(
+                controller: scrollController,
+                child: SizedBox(
+                  height: layoutMetrics.contentHeight,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _TimelineTimeLabels(
+                        width: layoutMetrics.labelWidth,
+                        headerHeight: animatedHeaderHeight,
+                        slotHeight: slotHeight,
+                        timeSlots: timeSlots,
+                        labelStyle: layoutMetrics.labelStyle,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: _TimelineGridAndContent(
+                          headerHeight: animatedHeaderHeight,
+                          slotHeight: slotHeight,
+                          timeSlotsCount: timeSlots.length,
+                          mode: mode,
+                          dayLabels: dayLabels,
+                          selectedDay: selectedDay,
+                          dayColumnWidth: layoutMetrics.dayColumnWidth,
+                          entriesForDay: entriesForDay,
+                          roomBuilder: roomBuilder,
+                          teacherBuilder: teacherBuilder,
+                          duration: duration,
+                          disableAnimations: disableAnimations,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  double _weekHeaderHeight(BuildContext context) {
+    final TextStyle style =
+        Theme.of(context).textTheme.bodySmall ?? const TextStyle();
+    final String dayLabel = AppLocalizations.of(context).weekdayMon;
+    const double padding = 8;
+    final TextPainter painter = TextPainter(
+      text: TextSpan(text: dayLabel, style: style),
+      maxLines: 1,
+      textDirection: TextDirection.ltr,
+    )..layout();
+    return painter.height + padding;
+  }
+
+  _TimelineLayoutMetrics _computeTimelineMetrics(
+    BuildContext context, {
+    required double maxWidth,
+    required int timeSlotsCount,
+    required double slotHeight,
+    required double animatedHeaderHeight,
+  }) {
+    const double preferredLabelWidth = 72;
+    const double minLabelWidth = 35;
+    const double minCardWidth = 92;
+    const double maxCardWidth = double.infinity;
+    final double availableWidth = (maxWidth - 8).clamp(0, double.infinity);
+
+    double labelWidth = preferredLabelWidth;
+    double dayColumnWidth =
+        ((availableWidth - labelWidth) / 7).clamp(0, maxCardWidth);
+
+    if (dayColumnWidth < minCardWidth) {
+      final double neededLabelWidth = availableWidth - minCardWidth * 7;
+      labelWidth = neededLabelWidth.clamp(minLabelWidth, preferredLabelWidth);
+      dayColumnWidth = ((availableWidth - labelWidth) / 7).clamp(0, maxCardWidth);
+    }
+
+    final bool isNarrowLabel = labelWidth <= minLabelWidth + 0.1;
+    final TextStyle? labelStyle = isNarrowLabel
+        ? Theme.of(context).textTheme.bodySmall?.copyWith(fontSize: 11)
+        : Theme.of(context).textTheme.bodySmall;
+
+    return _TimelineLayoutMetrics(
+      labelWidth: labelWidth,
+      dayColumnWidth: dayColumnWidth,
+      labelStyle: labelStyle,
+      contentHeight: timeSlotsCount * slotHeight + animatedHeaderHeight,
+    );
+  }
+}
+
+class _TimelineLayoutMetrics {
+  const _TimelineLayoutMetrics({
+    required this.labelWidth,
+    required this.dayColumnWidth,
+    required this.labelStyle,
+    required this.contentHeight,
+  });
+
+  final double labelWidth;
+  final double dayColumnWidth;
+  final TextStyle? labelStyle;
+  final double contentHeight;
+}
+
+class _TimelineTimeLabels extends StatelessWidget {
+  const _TimelineTimeLabels({
+    required this.width,
+    required this.headerHeight,
+    required this.slotHeight,
+    required this.timeSlots,
+    required this.labelStyle,
+  });
+
+  final double width;
+  final double headerHeight;
+  final double slotHeight;
+  final List<_TimeSlot> timeSlots;
+  final TextStyle? labelStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: width,
+      child: Column(
+        children: [
+          SizedBox(height: headerHeight),
+          for (final slot in timeSlots)
+            Container(
+              height: slotHeight,
+              alignment: Alignment.topCenter,
+              padding: const EdgeInsets.only(top: 6),
+              child: Text(slot.label, style: labelStyle),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TimelineGridAndContent extends StatelessWidget {
+  const _TimelineGridAndContent({
+    required this.headerHeight,
+    required this.slotHeight,
+    required this.timeSlotsCount,
+    required this.mode,
+    required this.dayLabels,
+    required this.selectedDay,
+    required this.dayColumnWidth,
+    required this.entriesForDay,
+    required this.roomBuilder,
+    required this.teacherBuilder,
+    required this.duration,
+    required this.disableAnimations,
+  });
+
+  final double headerHeight;
+  final double slotHeight;
+  final int timeSlotsCount;
+  final TimetableDisplayMode mode;
+  final List<String> dayLabels;
+  final int selectedDay;
+  final double dayColumnWidth;
+  final List<TimetableEntry> Function(int day) entriesForDay;
+  final String Function(TimetableEntry) roomBuilder;
+  final String Function(TimetableEntry) teacherBuilder;
+  final Duration duration;
+  final bool disableAnimations;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Column(
+            children: [
+              SizedBox(height: headerHeight),
+              for (int i = 0; i < timeSlotsCount; i += 1)
+                Container(
+                  height: slotHeight,
+                  decoration: BoxDecoration(
+                    border: Border(
+                      bottom: BorderSide(
+                        color: Theme.of(context).colorScheme.outlineVariant,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        Positioned.fill(
+          child: _ModeContentSwitcher(
+            mode: mode,
+            duration: duration,
+            disableAnimations: disableAnimations,
+            dayChild: KeyedSubtree(
+              key: const ValueKey<String>('day-content'),
+              child: DayTimelineContent(
+                entries: entriesForDay(selectedDay),
+                slotHeight: slotHeight,
+                slotCount: timeSlotsCount,
+                roomBuilder: roomBuilder,
+                teacherBuilder: teacherBuilder,
+              ),
+            ),
+            weekChild: KeyedSubtree(
+              key: const ValueKey<String>('week-content'),
+              child: WeekTimelineContent(
+                dayLabels: dayLabels,
+                dayColumnWidth: dayColumnWidth,
+                slotHeight: slotHeight,
+                slotCount: timeSlotsCount,
+                entriesForDay: entriesForDay,
+                roomBuilder: roomBuilder,
+                teacherBuilder: teacherBuilder,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ModeContentSwitcher extends StatelessWidget {
+  const _ModeContentSwitcher({
+    required this.mode,
+    required this.duration,
+    required this.disableAnimations,
+    required this.dayChild,
+    required this.weekChild,
+  });
+
+  final TimetableDisplayMode mode;
+  final Duration duration;
+  final bool disableAnimations;
+  final Widget dayChild;
+  final Widget weekChild;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: duration,
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeOut,
+      transitionBuilder: (child, animation) {
+        if (disableAnimations) {
+          return child;
+        }
+        return FadeTransition(
+          opacity: animation,
+          child: child,
+        );
+      },
+      layoutBuilder: (currentChild, previousChildren) {
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            ...previousChildren,
+            if (currentChild != null) currentChild,
+          ],
+        );
+      },
+      child: mode == TimetableDisplayMode.day ? dayChild : weekChild,
+    );
+  }
+}
+
+class _TimeSlot {
+  const _TimeSlot(this.label);
+
+  final String label;
+}
+
+List<_TimeSlot> _buildTimeSlots(List<TimePeriodRangeData> ranges) {
+  return ranges
+      .map((range) => _TimeSlot(TimeSlot.formatMinutes(range.startMinutes)))
+      .toList();
+}

--- a/lib/features/timetable/views/widgets/timetable_timeline_panel.dart
+++ b/lib/features/timetable/views/widgets/timetable_timeline_panel.dart
@@ -1,4 +1,4 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:onetj/features/timetable/view_models/timetable_view_model.dart';
@@ -108,7 +108,7 @@ class TimetableTimelinePanel extends StatelessWidget {
     final TextPainter painter = TextPainter(
       text: TextSpan(text: dayLabel, style: style),
       maxLines: 1,
-      textDirection: TextDirection.ltr,
+      textDirection: Directionality.of(context),
     )..layout();
     return painter.height + padding;
   }

--- a/lib/features/timetable/views/widgets/timetable_timeline_panel.dart
+++ b/lib/features/timetable/views/widgets/timetable_timeline_panel.dart
@@ -187,11 +187,27 @@ class _TimelineTimeLabels extends StatelessWidget {
         children: [
           SizedBox(height: headerHeight),
           for (final slot in timeSlots)
-            Container(
+            SizedBox(
               height: slotHeight,
-              alignment: Alignment.topCenter,
-              padding: const EdgeInsets.only(top: 6),
-              child: Text(slot.label, style: labelStyle),
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  Align(
+                    alignment: Alignment.topCenter,
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: 6),
+                      child: Text(slot.startLabel, style: labelStyle),
+                    ),
+                  ),
+                  Align(
+                    alignment: Alignment.bottomCenter,
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 3),
+                      child: Text(slot.endLabel, style: labelStyle),
+                    ),
+                  ),
+                ],
+              ),
             ),
         ],
       ),
@@ -329,13 +345,22 @@ class _ModeContentSwitcher extends StatelessWidget {
 }
 
 class _TimeSlot {
-  const _TimeSlot(this.label);
+  const _TimeSlot({
+    required this.startLabel,
+    required this.endLabel,
+  });
 
-  final String label;
+  final String startLabel;
+  final String endLabel;
 }
 
 List<_TimeSlot> _buildTimeSlots(List<TimePeriodRangeData> ranges) {
   return ranges
-      .map((range) => _TimeSlot(TimeSlot.formatMinutes(range.startMinutes)))
+      .map(
+        (range) => _TimeSlot(
+          startLabel: TimeSlot.formatMinutes(range.startMinutes),
+          endLabel: TimeSlot.formatMinutes(range.endMinutes),
+        ),
+      )
       .toList();
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -68,6 +68,7 @@
 
   "settingsMaxWeekTitle": "Max Weeks",
   "settingsMaxWeekSubtitle": "Used by the timetable to display available weeks",
+  "settingsMaxWeekInvalidFormat": "Max week must be a number.",
   "settingsMaxWeekInvalidRange": "Max week must be between 1 and 52.",
   "settingsTimeSlotsTitle": "Time Slots",
   "settingsTimeSlotsEmpty": "No time slots configured",
@@ -90,11 +91,27 @@
   "settingsTimeSlotsInvalidOverlap": "Adjacent slots must not overlap.",
   "settingsTimeSlotsInvalidOrder": "Time slots must be strictly increasing.",
   "settingsTimeSlotsResetToDefault": "Reset to defaults",
+  "settingsDashboardUpcomingTitle": "Dashboard Upcoming Courses",
+  "settingsDashboardUpcomingModeThisWeek": "This week",
+  "settingsDashboardUpcomingModeToday": "Today",
+  "settingsDashboardUpcomingModeCount": "By count",
+  "settingsDashboardUpcomingModeCountSummary": "Show up to {count} courses",
+  "@settingsDashboardUpcomingModeCountSummary": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "settingsDashboardUpcomingCountLabel": "Course count",
+  "settingsDashboardUpcomingCountHint": "Valid range: 1 to 20",
+  "settingsDashboardUpcomingCountInvalidFormat": "Course count must be a number.",
+  "settingsDashboardUpcomingCountInvalidRange": "Course count must be between 1 and 20.",
 
   "settingsAdvancedSectionTitle": "Advanced",
-  "settingsDeveloperTitle": "Developer Mode",
+  "settingsDeveloperTitle": "Developer Options",
   "settingsDeveloperSubtitle": "Diagnostics and logs",
-  "settingsDeveloperPageTitle": "Developer Mode",
+  "settingsDeveloperPageTitle": "Developer Options",
   "settingsLogsTitle": "Logs",
   "settingsLogsSubtitle": "View recent application logs",
   "settingsLogsEmpty": "No logs yet",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -27,6 +27,9 @@
   "emptyClassesToday": "No classes today",
   "dashboardUpcomingTitle": "Upcoming Courses",
   "dashboardUpcomingEmpty": "No upcoming courses this week",
+  "dashboardUpcomingEmptyThisWeek": "No upcoming courses this week",
+  "dashboardUpcomingEmptyToday": "No upcoming courses today",
+  "dashboardUpcomingEmptyByCount": "No upcoming courses",
   "weekLabel": "Week {week}",
   "@weekLabel": {
     "placeholders": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -91,7 +91,7 @@
     "settingsTimeSlotsInvalidOverlap": "相邻节次不能重叠。",
     "settingsTimeSlotsInvalidOrder": "节次时间必须严格递增。",
     "settingsTimeSlotsResetToDefault": "重置为默认值",
-    "settingsDashboardUpcomingTitle": "仪表板课程显示策略",
+    "settingsDashboardUpcomingTitle": "即将到来的课程",
     "settingsDashboardUpcomingModeThisWeek": "本周",
     "settingsDashboardUpcomingModeToday": "本日",
     "settingsDashboardUpcomingModeCount": "按节数",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -28,6 +28,9 @@
     "emptyClassesToday": "今天没有课哦",
     "dashboardUpcomingTitle": "即将到来的课程",
     "dashboardUpcomingEmpty": "本周暂无课程",
+    "dashboardUpcomingEmptyThisWeek": "本周暂无课程",
+    "dashboardUpcomingEmptyToday": "今日暂无课程",
+    "dashboardUpcomingEmptyByCount": "暂无即将到来的课程",
     "weekLabel": "第{week}周",
     "@weekLabel": {
       "placeholders": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -69,6 +69,7 @@
 
     "settingsMaxWeekTitle": "最大周数",
     "settingsMaxWeekSubtitle": "用于课程表显示可用周数",
+    "settingsMaxWeekInvalidFormat": "最大周数必须为数字",
     "settingsTimeSlotsTitle": "课程表时间设置",
     "settingsTimeSlotsEmpty": "未配置课程表时间",
     "settingsTimeSlotsSummary": "{count} 个节次 - {first} 到 {last}",
@@ -90,11 +91,27 @@
     "settingsTimeSlotsInvalidOverlap": "相邻节次不能重叠。",
     "settingsTimeSlotsInvalidOrder": "节次时间必须严格递增。",
     "settingsTimeSlotsResetToDefault": "重置为默认值",
+    "settingsDashboardUpcomingTitle": "仪表板课程显示策略",
+    "settingsDashboardUpcomingModeThisWeek": "本周",
+    "settingsDashboardUpcomingModeToday": "本日",
+    "settingsDashboardUpcomingModeCount": "按节数",
+    "settingsDashboardUpcomingModeCountSummary": "最多显示 {count} 节课",
+    "@settingsDashboardUpcomingModeCountSummary": {
+      "placeholders": {
+        "count": {
+          "type": "int"
+        }
+      }
+    },
+    "settingsDashboardUpcomingCountLabel": "课程节数",
+    "settingsDashboardUpcomingCountHint": "可设置范围：1 到 20",
+    "settingsDashboardUpcomingCountInvalidFormat": "课程节数必须为数字",
+    "settingsDashboardUpcomingCountInvalidRange": "课程节数必须在1到20之间",
 
     "settingsAdvancedSectionTitle": "高级",
-    "settingsDeveloperTitle": "开发者模式",
+    "settingsDeveloperTitle": "开发者选项",
     "settingsDeveloperSubtitle": "诊断与日志",
-    "settingsDeveloperPageTitle": "开发者模式",
+    "settingsDeveloperPageTitle": "开发者选项",
     "settingsLogsTitle": "日志",
     "settingsLogsSubtitle": "查看最近应用日志",
     "settingsLogsEmpty": "暂无日志",

--- a/lib/models/dashboard_upcoming_mode.dart
+++ b/lib/models/dashboard_upcoming_mode.dart
@@ -7,15 +7,18 @@ enum DashboardUpcomingMode {
 
   final String jsonValue;
 
-  static DashboardUpcomingMode fromJsonValue(Object? value) {
+  static DashboardUpcomingMode fromJsonValue(
+    Object? value, {
+    DashboardUpcomingMode defaultValue = DashboardUpcomingMode.thisWeek,
+  }) {
     if (value is! String) {
-      return DashboardUpcomingMode.thisWeek;
+      return defaultValue;
     }
     for (final DashboardUpcomingMode mode in DashboardUpcomingMode.values) {
       if (mode.jsonValue == value) {
         return mode;
       }
     }
-    return DashboardUpcomingMode.thisWeek;
+    return defaultValue;
   }
 }

--- a/lib/models/dashboard_upcoming_mode.dart
+++ b/lib/models/dashboard_upcoming_mode.dart
@@ -1,0 +1,21 @@
+enum DashboardUpcomingMode {
+  thisWeek('thisWeek'),
+  today('today'),
+  count('count');
+
+  const DashboardUpcomingMode(this.jsonValue);
+
+  final String jsonValue;
+
+  static DashboardUpcomingMode fromJsonValue(Object? value) {
+    if (value is! String) {
+      return DashboardUpcomingMode.thisWeek;
+    }
+    for (final DashboardUpcomingMode mode in DashboardUpcomingMode.values) {
+      if (mode.jsonValue == value) {
+        return mode;
+      }
+    }
+    return DashboardUpcomingMode.thisWeek;
+  }
+}

--- a/lib/models/settings_defaults.dart
+++ b/lib/models/settings_defaults.dart
@@ -1,6 +1,12 @@
+import 'package:onetj/models/dashboard_upcoming_mode.dart';
 import 'package:onetj/models/time_period_range.dart';
 
 const int kDefaultMaxWeek = 22;
+const DashboardUpcomingMode kDefaultDashboardUpcomingMode =
+    DashboardUpcomingMode.today;
+const int kDefaultDashboardUpcomingCount = 3;
+const int kMinDashboardUpcomingCount = 1;
+const int kMaxDashboardUpcomingCount = 20;
 
 const int kLegacyTimeSlotLastDurationMinutes = 45;
 

--- a/lib/repo/settings_repository.dart
+++ b/lib/repo/settings_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:onetj/models/dashboard_upcoming_mode.dart';
 import 'package:onetj/models/settings_defaults.dart';
 import 'package:onetj/models/settings_validation.dart' as settings_validation;
 import 'package:onetj/models/time_period_range.dart';
@@ -11,10 +12,14 @@ class SettingsData {
   const SettingsData({
     required this.maxWeek,
     required this.timeSlotRanges,
+    required this.dashboardUpcomingMode,
+    required this.dashboardUpcomingCount,
   });
 
   final int maxWeek;
   final List<TimePeriodRangeData> timeSlotRanges;
+  final DashboardUpcomingMode dashboardUpcomingMode;
+  final int dashboardUpcomingCount;
 
   factory SettingsData.fromJson(Map<String, dynamic> json) {
     final int maxWeek = _readMaxWeekWithFallback(json);
@@ -23,6 +28,8 @@ class SettingsData {
     return SettingsData(
       maxWeek: maxWeek,
       timeSlotRanges: timeSlotRanges,
+      dashboardUpcomingMode: _readDashboardUpcomingModeWithFallback(json),
+      dashboardUpcomingCount: _readDashboardUpcomingCountWithFallback(json),
     );
   }
 
@@ -30,6 +37,8 @@ class SettingsData {
     return {
       'maxWeek': maxWeek,
       'timeSlotRanges': timeSlotRanges.map((item) => item.toJson()).toList(),
+      'dashboardUpcomingMode': dashboardUpcomingMode.jsonValue,
+      'dashboardUpcomingCount': dashboardUpcomingCount,
     };
   }
 
@@ -69,6 +78,32 @@ class SettingsData {
       }
     }
     return _defaultTimeSlotRanges();
+  }
+
+  static DashboardUpcomingMode _readDashboardUpcomingModeWithFallback(
+    Map<String, dynamic> json,
+  ) {
+    if (!json.containsKey('dashboardUpcomingMode')) {
+      return kDefaultDashboardUpcomingMode;
+    }
+    return DashboardUpcomingMode.fromJsonValue(json['dashboardUpcomingMode']);
+  }
+
+  static int _readDashboardUpcomingCountWithFallback(
+    Map<String, dynamic> json,
+  ) {
+    if (!json.containsKey('dashboardUpcomingCount')) {
+      return kDefaultDashboardUpcomingCount;
+    }
+    final Object? value = json['dashboardUpcomingCount'];
+    if (value is! int) {
+      return kDefaultDashboardUpcomingCount;
+    }
+    if (value < kMinDashboardUpcomingCount ||
+        value > kMaxDashboardUpcomingCount) {
+      return kDefaultDashboardUpcomingCount;
+    }
+    return value;
   }
 
   static int _parseMaxWeek(Object? value) {
@@ -192,6 +227,8 @@ class SettingsRepository {
   static final SettingsData _defaultSettings = SettingsData(
     maxWeek: kDefaultMaxWeek,
     timeSlotRanges: kDefaultTimeSlotRanges,
+    dashboardUpcomingMode: kDefaultDashboardUpcomingMode,
+    dashboardUpcomingCount: kDefaultDashboardUpcomingCount,
   );
 
   static SettingsRepository getInstance() {

--- a/lib/repo/settings_repository.dart
+++ b/lib/repo/settings_repository.dart
@@ -86,7 +86,10 @@ class SettingsData {
     if (!json.containsKey('dashboardUpcomingMode')) {
       return kDefaultDashboardUpcomingMode;
     }
-    return DashboardUpcomingMode.fromJsonValue(json['dashboardUpcomingMode']);
+    return DashboardUpcomingMode.fromJsonValue(
+      json['dashboardUpcomingMode'],
+      defaultValue: kDefaultDashboardUpcomingMode,
+    );
   }
 
   static int _readDashboardUpcomingCountWithFallback(

--- a/local_packages/flutter_inappwebview/flutter_inappwebview_windows/windows/CMakeLists.txt
+++ b/local_packages/flutter_inappwebview/flutter_inappwebview_windows/windows/CMakeLists.txt
@@ -33,7 +33,6 @@ add_custom_command(
   COMMAND ${NUGET} install Microsoft.Windows.ImplementationLibrary -Version ${WIL_VERSION} -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages
   COMMAND ${NUGET} install Microsoft.Web.WebView2 -Version ${WEBVIEW_VERSION} -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages
   COMMAND ${NUGET} install nlohmann.json -Version ${NLOHMANN_JSON} -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages
-  DEPENDS ${NUGET}
 )
 
 # Any new source files that you add to the plugin should be added here.

--- a/test/features/dashboard/upcoming_entries_calculator_test.dart
+++ b/test/features/dashboard/upcoming_entries_calculator_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onetj/features/dashboard/models/upcoming_entries_calculator.dart';
+import 'package:onetj/models/dashboard_upcoming_mode.dart';
+import 'package:onetj/models/time_period_range.dart';
+import 'package:onetj/models/timetable_index.dart';
+
+void main() {
+  const List<TimePeriodRangeData> ranges = <TimePeriodRangeData>[
+    TimePeriodRangeData(startMinutes: 8 * 60, endMinutes: 8 * 60 + 45),
+    TimePeriodRangeData(startMinutes: 9 * 60, endMinutes: 9 * 60 + 45),
+    TimePeriodRangeData(startMinutes: 10 * 60, endMinutes: 10 * 60 + 45),
+  ];
+
+  TimetableEntry entry({
+    required String id,
+    required int day,
+    required int start,
+    required List<int> weeks,
+  }) {
+    return TimetableEntry(
+      courseName: id,
+      courseCode: id,
+      classCode: id,
+      className: id,
+      teacherName: 't',
+      campus: '',
+      campusI18n: '',
+      roomId: '',
+      roomIdI18n: '',
+      roomLabel: '',
+      dayOfWeek: day,
+      timeStart: start,
+      timeEnd: start,
+      weeks: weeks,
+      weekNum: '',
+      teachingClassId: null,
+    );
+  }
+
+  group('UpcomingEntriesCalculator', () {
+    test('today mode returns only today entries after now', () {
+      final List<TimetableEntry> entries = <TimetableEntry>[
+        entry(id: 'today-past', day: 1, start: 1, weeks: <int>[5]),
+        entry(id: 'today-future', day: 1, start: 3, weeks: <int>[5]),
+        entry(id: 'tomorrow', day: 2, start: 1, weeks: <int>[5]),
+      ];
+      final UpcomingEntriesQuery query = UpcomingEntriesQuery(
+        now: DateTime(2026, 1, 26, 9, 30), // Monday
+        entries: entries,
+        timeSlotRanges: ranges,
+        currentWeek: 5,
+        maxWeek: 20,
+        mode: DashboardUpcomingMode.today,
+        count: 3,
+      );
+
+      final List<TimetableEntry> result =
+          UpcomingEntriesCalculator.calculate(query);
+
+      expect(result.map((e) => e.courseName), <String>['today-future']);
+    });
+
+    test('thisWeek mode returns remaining entries in current week', () {
+      final List<TimetableEntry> entries = <TimetableEntry>[
+        entry(id: 'today-past', day: 1, start: 1, weeks: <int>[5]),
+        entry(id: 'today-future', day: 1, start: 3, weeks: <int>[5]),
+        entry(id: 'wed', day: 3, start: 1, weeks: <int>[5]),
+        entry(id: 'next-week', day: 1, start: 1, weeks: <int>[6]),
+      ];
+      final UpcomingEntriesQuery query = UpcomingEntriesQuery(
+        now: DateTime(2026, 1, 26, 9, 30), // Monday
+        entries: entries,
+        timeSlotRanges: ranges,
+        currentWeek: 5,
+        maxWeek: 20,
+        mode: DashboardUpcomingMode.thisWeek,
+        count: 3,
+      );
+
+      final List<TimetableEntry> result =
+          UpcomingEntriesCalculator.calculate(query);
+
+      expect(result.map((e) => e.courseName), <String>['today-future', 'wed']);
+    });
+
+    test('count mode fills across weeks up to count', () {
+      final List<TimetableEntry> entries = <TimetableEntry>[
+        entry(id: 'w5-mon', day: 1, start: 3, weeks: <int>[5]),
+        entry(id: 'w5-tue', day: 2, start: 1, weeks: <int>[5]),
+        entry(id: 'w6-mon', day: 1, start: 1, weeks: <int>[6]),
+        entry(id: 'w6-wed', day: 3, start: 1, weeks: <int>[6]),
+      ];
+      final UpcomingEntriesQuery query = UpcomingEntriesQuery(
+        now: DateTime(2026, 1, 26, 9, 30), // Monday week 5
+        entries: entries,
+        timeSlotRanges: ranges,
+        currentWeek: 5,
+        maxWeek: 20,
+        mode: DashboardUpcomingMode.count,
+        count: 3,
+      );
+
+      final List<TimetableEntry> result =
+          UpcomingEntriesCalculator.calculate(query);
+
+      expect(
+        result.map((e) => e.courseName),
+        <String>['w5-mon', 'w5-tue', 'w6-mon'],
+      );
+    });
+
+    test('count mode returns empty when currentWeek > maxWeek', () {
+      final UpcomingEntriesQuery query = UpcomingEntriesQuery(
+        now: DateTime(2026, 1, 26, 9, 30),
+        entries: <TimetableEntry>[
+          entry(id: 'a', day: 1, start: 3, weeks: <int>[8]),
+        ],
+        timeSlotRanges: ranges,
+        currentWeek: 8,
+        maxWeek: 7,
+        mode: DashboardUpcomingMode.count,
+        count: 3,
+      );
+
+      final List<TimetableEntry> result =
+          UpcomingEntriesCalculator.calculate(query);
+
+      expect(result, isEmpty);
+    });
+  });
+}

--- a/test/features/settings_model_test.dart
+++ b/test/features/settings_model_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onetj/app/exception/app_exception.dart';
+import 'package:onetj/features/settings/models/settings_model.dart';
+
+void main() {
+  group('SettingsModel.parseMaxWeekText', () {
+    test('parses valid number', () {
+      expect(SettingsModel.parseMaxWeekText('12'), 12);
+      expect(SettingsModel.parseMaxWeekText(' 7 '), 7);
+    });
+
+    test('throws invalid format for empty or non-number', () {
+      expect(
+        () => SettingsModel.parseMaxWeekText(''),
+        throwsA(
+          isA<SettingsValidationException>().having(
+            (e) => e.code,
+            'code',
+            SettingsValidationException.maxWeekInvalidFormat,
+          ),
+        ),
+      );
+      expect(
+        () => SettingsModel.parseMaxWeekText('abc'),
+        throwsA(
+          isA<SettingsValidationException>().having(
+            (e) => e.code,
+            'code',
+            SettingsValidationException.maxWeekInvalidFormat,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('SettingsModel.parseDashboardUpcomingCountText', () {
+    test('parses valid number', () {
+      expect(SettingsModel.parseDashboardUpcomingCountText('3'), 3);
+      expect(SettingsModel.parseDashboardUpcomingCountText(' 10 '), 10);
+    });
+
+    test('throws invalid format for empty or non-number', () {
+      expect(
+        () => SettingsModel.parseDashboardUpcomingCountText(''),
+        throwsA(
+          isA<SettingsValidationException>().having(
+            (e) => e.code,
+            'code',
+            SettingsValidationException.dashboardUpcomingCountInvalidFormat,
+          ),
+        ),
+      );
+      expect(
+        () => SettingsModel.parseDashboardUpcomingCountText('abc'),
+        throwsA(
+          isA<SettingsValidationException>().having(
+            (e) => e.code,
+            'code',
+            SettingsValidationException.dashboardUpcomingCountInvalidFormat,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('SettingsModel.validateDashboardUpcomingCount', () {
+    test('accepts value within range', () {
+      expect(
+        () => SettingsModel.validateDashboardUpcomingCount(1),
+        returnsNormally,
+      );
+      expect(
+        () => SettingsModel.validateDashboardUpcomingCount(20),
+        returnsNormally,
+      );
+    });
+
+    test('throws for out-of-range value', () {
+      expect(
+        () => SettingsModel.validateDashboardUpcomingCount(0),
+        throwsA(
+          isA<SettingsValidationException>().having(
+            (e) => e.code,
+            'code',
+            SettingsValidationException.dashboardUpcomingCountOutOfRange,
+          ),
+        ),
+      );
+      expect(
+        () => SettingsModel.validateDashboardUpcomingCount(21),
+        throwsA(
+          isA<SettingsValidationException>().having(
+            (e) => e.code,
+            'code',
+            SettingsValidationException.dashboardUpcomingCountOutOfRange,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/updateLog.md
+++ b/updateLog.md
@@ -1,0 +1,91 @@
+2.2.0 (7)
+---
+Version: 2.2.0
+Build Time: 2026.03.02-09:36
+
+### Update Log:
++ 新增课程时间段配置与校验逻辑
++ 设置页支持时间槽编辑、异常处理与开发者模式
++ 新增应用日志系统，并提供日志查看能力
++ 修复默认时间槽结束分钟数问题并优化构建配置
+
+### Contributors:
+[oierxjn](https://github.com/oierxjn)
+
+2.1.0 (6)
+---
+Version: 2.1.0
+Build Time: 2026.02.11-12:37
+
+### Update Log:
++ 新增成绩查询功能（含本科生成绩模型、接口与缓存）
++ 新增工具页入口并接入成绩相关视图
++ 重构设置页状态管理，补充最大周数与重置设置能力
++ 优化课表滚动同步及错误处理，提升交互稳定性
+
+### Contributors:
+[oierxjn](https://github.com/oierxjn)
+
+2.0.0 (5)
+---
+Version: 2.0.0
+Build Time: 2026.02.05-00:58
+
+### Update Log:
++ 完成跨平台重构，统一 Android/Windows/OpenHarmony 基础能力
++ 实现登录与鉴权流程（OAuth、Token 存储与刷新）
++ 新增首页与课程表模块，支持教学周展示和“跳转到今天”
++ 完成设置、路由与本地化重构，优化多语言与导航结构
++ 增强异常处理、缓存持久化与网络解析稳定性
++ 新增 Windows 安装包配置及应用图标资源
+
+### Contributors:
+[oierxjn](https://github.com/oierxjn)
+
+1.1.0 (4)
+---
+Version: 1.1.0
+Build Time: 2026.01.28-13:05
+
+### Update Log:
++ 新增绩点查询功能
+- 删除通知详情中的其他应用打开按钮
+
+### Contributors:
+[oierxjn](https://github.com/oierxjn)
+
+1.0.1 (3)
+---
+Version: 1.0.1
+Build Time: 2025.12.28-21:05
+
+### Update Log:
+* 优化UI设计
+* 大规模重构兼容
+
+### Contributors:
+[oierxjn](https://github.com/oierxjn)  
+[streetartist](https://github.com/streetartist)
+
+1.0.0 (2)
+---
+Version: 1.0.0  
+Build Time: 2025.12.26-0:32
+
+### Update Log:
++ 隐私政策页面
+
+### Contributors:
+[oierxjn](https://github.com/oierxjn)
+
+0.0.1 (1)
+---
+Version: 0.0.1  
+Build Time: 2025.12.25-20:41
+
+### Update Log:
++ 单日课表
++ 物理实验计算
+
+### Contributors:
+[oierxjn](https://github.com/oierxjn)


### PR DESCRIPTION
  ## 主要变更

  - 时间表（timetable）
      - 时间标签同时显示开始与结束时间
      - 视图逻辑拆分为独立组件
      - 增加动画支持并优化布局切换体验
  - 仪表板（dashboard）
      - 优化“即将到来课程”计算逻辑
      - 调整课程卡片布局与时间显示格式
  - 设置（settings）
      - 新增仪表板课程显示策略配置
      - 设置页与课程卡片组件重构，提升可维护性
  - 其他
      - 新增更新日志
      - 补充/调整中英文文案