### PR TITLE
Build(windows): 添加卸载时清理用户数据和日志的配置

### DIFF
--- a/setup.iss
+++ b/setup.iss
@@ -22,3 +22,10 @@ Name: "desktopicon"; Description: "Create a &desktop icon"; GroupDescription: "A
 
 [Run]
 Filename: "{app}\onetj.exe"; Description: "Run OneTJ"; Flags: nowait postinstall skipifsilent
+
+[UninstallDelete]
+Type: filesandordirs; Name: "{userappdata}\onetj\hive"
+Type: filesandordirs; Name: "{userappdata}\onetj\logs"
+Type: filesandordirs; Name: "{localappdata}\OneTJ\EBWebView"
+Type: dirifempty; Name: "{userappdata}\onetj"
+Type: dirifempty; Name: "{localappdata}\OneTJ"


### PR DESCRIPTION
在卸载时自动删除用户数据目录中的 hive 和 logs 文件夹，以及 EBWebView 缓存目录 同时清理空的 onetj 和 OneTJ 目录