### PR TITLE
Fix(device_info): 更新device_info_plus依赖版本并修复ohos设备信息获取

### DIFF
--- a/lib/services/device_info_service.dart
+++ b/lib/services/device_info_service.dart
@@ -51,7 +51,7 @@ class DeviceInfoService {
           platform: 'android',
         );
       case TargetPlatform.ohos:
-        final OhosDeviceInfo info = await _plugin.ohosInfo;
+        final info = await _plugin.ohosDeviceInfo;
         return DeviceInfoData(
           brand: _pickFirstNonBlank(
             <String?>[info.brand, info.manufacture],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,20 +197,20 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/device_info_plus/device_info_plus"
-      ref: "br_device_info_plus_v11.4.0_ohos"
-      resolved-ref: "03507cc39ab148fe9f5827cd991b3e04aed2bcc3"
+      ref: "br_device_info_plus-v11.1.0_ohos"
+      resolved-ref: "9f92933f2ac78bb3d7ec534f22bc3183a257fbb9"
       url: "https://gitcode.com/openharmony-sig/flutter_plus_plugins.git"
     source: git
-    version: "9.1.0"
+    version: "11.1.0"
   device_info_plus_platform_interface:
     dependency: "direct overridden"
     description:
       path: "packages/device_info_plus/device_info_plus_platform_interface"
-      ref: "br_device_info_plus_v11.4.0_ohos"
-      resolved-ref: "03507cc39ab148fe9f5827cd991b3e04aed2bcc3"
+      ref: "br_device_info_plus-v11.1.0_ohos"
+      resolved-ref: "9f92933f2ac78bb3d7ec534f22bc3183a257fbb9"
       url: "https://gitcode.com/openharmony-sig/flutter_plus_plugins.git"
     source: git
-    version: "7.0.0"
+    version: "7.0.1"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -128,12 +128,12 @@ dependency_overrides:
   device_info_plus:
     git:
       url: "https://gitcode.com/openharmony-sig/flutter_plus_plugins.git"
-      ref: "br_device_info_plus_v11.4.0_ohos"
+      ref: "br_device_info_plus-v11.1.0_ohos"
       path: "packages/device_info_plus/device_info_plus"
   device_info_plus_platform_interface:
     git:
       url: "https://gitcode.com/openharmony-sig/flutter_plus_plugins.git"
-      ref: "br_device_info_plus_v11.4.0_ohos"
+      ref: "br_device_info_plus-v11.1.0_ohos"
       path: "packages/device_info_plus/device_info_plus_platform_interface"
   flutter_inappwebview_platform_interface:
     path: ./local_packages/flutter_inappwebview/flutter_inappwebview_platform_interface


### PR DESCRIPTION
将device_info_plus依赖从v11.4.0降级至v11.1.0以解决兼容性问题
同时修复ohos平台设备信息获取接口名称错误