### PR TITLE
2.4.4 Refactor calibration logic and enhance wavelength measurement display

### DIFF
--- a/lib/app/constant/app_version_constant.dart
+++ b/lib/app/constant/app_version_constant.dart
@@ -1,3 +1,3 @@
 const String oneTJAppName = 'OneTJ';
-const String oneTJAppVersion = '2.4.3';
-const String oneTJAppBuildNumber = '15';
+const String oneTJAppVersion = '2.4.4';
+const String oneTJAppBuildNumber = '16';

--- a/lib/features/physics_lab/features/diffraction_grating/models/diffraction_grating_wavelength_result.dart
+++ b/lib/features/physics_lab/features/diffraction_grating/models/diffraction_grating_wavelength_result.dart
@@ -5,11 +5,13 @@ class DiffractionGratingWavelengthRowResult {
     required this.order,
     required this.measurement,
     required this.wavelengthNm,
+    required this.relativeErrorPercent,
   });
 
   final int order;
   final DiffractionGratingMeasurementResult measurement;
   final double wavelengthNm;
+  final double relativeErrorPercent;
 }
 
 class DiffractionGratingWavelengthGroupResult {

--- a/lib/features/physics_lab/features/diffraction_grating/view_models/diffraction_grating_view_model.dart
+++ b/lib/features/physics_lab/features/diffraction_grating/view_models/diffraction_grating_view_model.dart
@@ -55,6 +55,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
 
   String _calibrationReferenceText =
       defaultCalibrationReferenceWavelengthNm.toStringAsFixed(2);
+  _DiffractionGratingDerivedState? _derivedState;
 
   List<List<String>> get calibrationTexts => _clone2d(_calibrationTexts);
   List<List<List<String>>> get wavelengthTexts => _clone3d(_wavelengthTexts);
@@ -63,25 +64,13 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
   String get calibrationReferenceText => _calibrationReferenceText;
 
   DiffractionGratingCalibrationResult? get calibrationResult =>
-      _buildCalibrationResult();
+      _getDerivedState().calibrationResult;
 
   List<List<DiffractionGratingWavelengthRowResult?>> get wavelengthRowResults =>
-      List<List<DiffractionGratingWavelengthRowResult?>>.generate(
-        wavelengthGroupCount,
-        (int groupIndex) => List<DiffractionGratingWavelengthRowResult?>.generate(
-          wavelengthRowCount,
-          (int rowIndex) => _buildWavelengthRowResult(groupIndex, rowIndex),
-          growable: false,
-        ),
-        growable: false,
-      );
+      _getDerivedState().wavelengthRowResults;
 
   List<DiffractionGratingWavelengthGroupResult?> get wavelengthResults =>
-      List<DiffractionGratingWavelengthGroupResult?>.generate(
-        wavelengthGroupCount,
-        _buildWavelengthGroupResult,
-        growable: false,
-      );
+      _getDerivedState().wavelengthResults;
 
   void updateCalibrationReading(int rowIndex, int readingIndex, String value) {
     if (!_isValidCalibrationCell(rowIndex, readingIndex)) {
@@ -91,6 +80,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       return;
     }
     _calibrationTexts[rowIndex][readingIndex] = value;
+    _invalidateDerivedState();
     notifyListeners();
   }
 
@@ -107,6 +97,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       return;
     }
     _wavelengthTexts[groupIndex][rowIndex][readingIndex] = value;
+    _invalidateDerivedState();
     notifyListeners();
   }
 
@@ -115,6 +106,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       return;
     }
     _calibrationReferenceText = value;
+    _invalidateDerivedState();
     notifyListeners();
   }
 
@@ -126,6 +118,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       return;
     }
     _referenceWavelengthTexts[groupIndex] = value;
+    _invalidateDerivedState();
     notifyListeners();
   }
 
@@ -152,6 +145,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
     }
     _referenceWavelengthTexts[0] = '435.84';
     _referenceWavelengthTexts[1] = '585.94';
+    _invalidateDerivedState();
     notifyListeners();
   }
 
@@ -190,8 +184,67 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       }
     }
     if (changed) {
+      _invalidateDerivedState();
       notifyListeners();
     }
+  }
+
+  _DiffractionGratingDerivedState _getDerivedState() {
+    return _derivedState ??= _buildDerivedState();
+  }
+
+  void _invalidateDerivedState() {
+    _derivedState = null;
+  }
+
+  _DiffractionGratingDerivedState _buildDerivedState() {
+    final DiffractionGratingCalibrationResult? calibrationResult =
+        _buildCalibrationResult();
+    final List<double?> referenceWavelengths = List<double?>.generate(
+      wavelengthGroupCount,
+      _parseReferenceWavelength,
+      growable: false,
+    );
+    final List<List<DiffractionGratingWavelengthRowResult?>> wavelengthRowResults =
+        List<List<DiffractionGratingWavelengthRowResult?>>.generate(
+          wavelengthGroupCount,
+          (int groupIndex) => List<DiffractionGratingWavelengthRowResult?>.generate(
+            wavelengthRowCount,
+            (int rowIndex) => _buildWavelengthRowResult(
+              calibrationResult: calibrationResult,
+              referenceNm: referenceWavelengths[groupIndex],
+              groupIndex: groupIndex,
+              rowIndex: rowIndex,
+            ),
+            growable: false,
+          ),
+          growable: false,
+        );
+    final List<DiffractionGratingWavelengthGroupResult?> wavelengthResults =
+        List<DiffractionGratingWavelengthGroupResult?>.generate(
+          wavelengthGroupCount,
+          (int groupIndex) => _buildWavelengthGroupResult(
+            calibrationResult: calibrationResult,
+            referenceNm: referenceWavelengths[groupIndex],
+            rowResults: wavelengthRowResults[groupIndex],
+          ),
+          growable: false,
+        );
+    return _DiffractionGratingDerivedState(
+      calibrationResult: calibrationResult,
+      wavelengthRowResults: List<List<DiffractionGratingWavelengthRowResult?>>.unmodifiable(
+        wavelengthRowResults
+            .map(
+              (List<DiffractionGratingWavelengthRowResult?> rows) =>
+                  List<DiffractionGratingWavelengthRowResult?>.unmodifiable(rows),
+            )
+            .toList(growable: false),
+      ),
+      wavelengthResults:
+          List<DiffractionGratingWavelengthGroupResult?>.unmodifiable(
+            wavelengthResults,
+          ),
+    );
   }
 
   DiffractionGratingCalibrationResult? _buildCalibrationResult() {
@@ -228,23 +281,17 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
     );
   }
 
-  DiffractionGratingWavelengthGroupResult? _buildWavelengthGroupResult(
-    int groupIndex,
-  ) {
-    final DiffractionGratingCalibrationResult? calibration = calibrationResult;
-    if (calibration == null) {
+  DiffractionGratingWavelengthGroupResult? _buildWavelengthGroupResult({
+    required DiffractionGratingCalibrationResult? calibrationResult,
+    required double? referenceNm,
+    required List<DiffractionGratingWavelengthRowResult?> rowResults,
+  }) {
+    if (calibrationResult == null || referenceNm == null) {
       return null;
     }
-    final double? referenceNm = _parseReferenceWavelength(groupIndex);
-    if (referenceNm == null) {
-      return null;
-    }
-
     final List<DiffractionGratingWavelengthRowResult> rows =
         <DiffractionGratingWavelengthRowResult>[];
-    for (int rowIndex = 0; rowIndex < wavelengthRowCount; rowIndex += 1) {
-      final DiffractionGratingWavelengthRowResult? rowResult =
-          _buildWavelengthRowResult(groupIndex, rowIndex);
+    for (final DiffractionGratingWavelengthRowResult? rowResult in rowResults) {
       if (rowResult == null) {
         return null;
       }
@@ -258,7 +305,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
     final double relativeErrorPercent =
         ((averageWavelengthNm - referenceNm).abs() / referenceNm) * 100;
     return DiffractionGratingWavelengthGroupResult(
-      averageGratingConstantMm: calibration.averageGratingConstantMm,
+      averageGratingConstantMm: calibrationResult.averageGratingConstantMm,
       referenceWavelengthNm: referenceNm,
       rows: List<DiffractionGratingWavelengthRowResult>.unmodifiable(rows),
       averageWavelengthNm: averageWavelengthNm,
@@ -266,16 +313,13 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
     );
   }
 
-  DiffractionGratingWavelengthRowResult? _buildWavelengthRowResult(
-    int groupIndex,
-    int rowIndex,
-  ) {
-    final DiffractionGratingCalibrationResult? calibration = calibrationResult;
-    if (calibration == null) {
-      return null;
-    }
-    final double? referenceNm = _parseReferenceWavelength(groupIndex);
-    if (referenceNm == null) {
+  DiffractionGratingWavelengthRowResult? _buildWavelengthRowResult({
+    required DiffractionGratingCalibrationResult? calibrationResult,
+    required double? referenceNm,
+    required int groupIndex,
+    required int rowIndex,
+  }) {
+    if (calibrationResult == null || referenceNm == null) {
       return null;
     }
     final DiffractionGratingMeasurementResult? measurement =
@@ -285,7 +329,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
     }
     final int order = wavelengthOrders[rowIndex];
     final double wavelengthNm =
-        (calibration.averageGratingConstantMm / nmToMm) *
+        (calibrationResult.averageGratingConstantMm / nmToMm) *
         measurement.sinGamma /
         order;
     final double relativeErrorPercent =
@@ -387,4 +431,16 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
           .toList(growable: false),
     );
   }
+}
+
+class _DiffractionGratingDerivedState {
+  const _DiffractionGratingDerivedState({
+    required this.calibrationResult,
+    required this.wavelengthRowResults,
+    required this.wavelengthResults,
+  });
+
+  final DiffractionGratingCalibrationResult? calibrationResult;
+  final List<List<DiffractionGratingWavelengthRowResult?>> wavelengthRowResults;
+  final List<DiffractionGratingWavelengthGroupResult?> wavelengthResults;
 }

--- a/lib/features/physics_lab/features/diffraction_grating/view_models/diffraction_grating_view_model.dart
+++ b/lib/features/physics_lab/features/diffraction_grating/view_models/diffraction_grating_view_model.dart
@@ -65,6 +65,17 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
   DiffractionGratingCalibrationResult? get calibrationResult =>
       _buildCalibrationResult();
 
+  List<List<DiffractionGratingWavelengthRowResult?>> get wavelengthRowResults =>
+      List<List<DiffractionGratingWavelengthRowResult?>>.generate(
+        wavelengthGroupCount,
+        (int groupIndex) => List<DiffractionGratingWavelengthRowResult?>.generate(
+          wavelengthRowCount,
+          (int rowIndex) => _buildWavelengthRowResult(groupIndex, rowIndex),
+          growable: false,
+        ),
+        growable: false,
+      );
+
   List<DiffractionGratingWavelengthGroupResult?> get wavelengthResults =>
       List<DiffractionGratingWavelengthGroupResult?>.generate(
         wavelengthGroupCount,
@@ -224,33 +235,20 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
     if (calibration == null) {
       return null;
     }
-
-    final double? referenceNm =
-        double.tryParse(_referenceWavelengthTexts[groupIndex].trim());
-    if (referenceNm == null || referenceNm <= 0) {
+    final double? referenceNm = _parseReferenceWavelength(groupIndex);
+    if (referenceNm == null) {
       return null;
     }
 
     final List<DiffractionGratingWavelengthRowResult> rows =
         <DiffractionGratingWavelengthRowResult>[];
     for (int rowIndex = 0; rowIndex < wavelengthRowCount; rowIndex += 1) {
-      final DiffractionGratingMeasurementResult? measurement =
-          _buildMeasurementResult(_wavelengthTexts[groupIndex][rowIndex]);
-      if (measurement == null) {
+      final DiffractionGratingWavelengthRowResult? rowResult =
+          _buildWavelengthRowResult(groupIndex, rowIndex);
+      if (rowResult == null) {
         return null;
       }
-      final int order = wavelengthOrders[rowIndex];
-      final double wavelengthNm =
-          (calibration.averageGratingConstantMm / nmToMm) *
-          measurement.sinGamma /
-          order;
-      rows.add(
-        DiffractionGratingWavelengthRowResult(
-          order: order,
-          measurement: measurement,
-          wavelengthNm: wavelengthNm,
-        ),
-      );
+      rows.add(rowResult);
     }
 
     final double averageWavelengthNm = rows
@@ -266,6 +264,47 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       averageWavelengthNm: averageWavelengthNm,
       relativeErrorPercent: relativeErrorPercent,
     );
+  }
+
+  DiffractionGratingWavelengthRowResult? _buildWavelengthRowResult(
+    int groupIndex,
+    int rowIndex,
+  ) {
+    final DiffractionGratingCalibrationResult? calibration = calibrationResult;
+    if (calibration == null) {
+      return null;
+    }
+    final double? referenceNm = _parseReferenceWavelength(groupIndex);
+    if (referenceNm == null) {
+      return null;
+    }
+    final DiffractionGratingMeasurementResult? measurement =
+        _buildMeasurementResult(_wavelengthTexts[groupIndex][rowIndex]);
+    if (measurement == null) {
+      return null;
+    }
+    final int order = wavelengthOrders[rowIndex];
+    final double wavelengthNm =
+        (calibration.averageGratingConstantMm / nmToMm) *
+        measurement.sinGamma /
+        order;
+    final double relativeErrorPercent =
+        ((wavelengthNm - referenceNm).abs() / referenceNm) * 100;
+    return DiffractionGratingWavelengthRowResult(
+      order: order,
+      measurement: measurement,
+      wavelengthNm: wavelengthNm,
+      relativeErrorPercent: relativeErrorPercent,
+    );
+  }
+
+  double? _parseReferenceWavelength(int groupIndex) {
+    final double? referenceNm =
+        double.tryParse(_referenceWavelengthTexts[groupIndex].trim());
+    if (referenceNm == null || referenceNm <= 0) {
+      return null;
+    }
+    return referenceNm;
   }
 
   DiffractionGratingMeasurementResult? _buildMeasurementResult(

--- a/lib/features/physics_lab/features/diffraction_grating/view_models/diffraction_grating_view_model.dart
+++ b/lib/features/physics_lab/features/diffraction_grating/view_models/diffraction_grating_view_model.dart
@@ -8,17 +8,16 @@ import 'package:onetj/models/base_model.dart';
 
 class DiffractionGratingViewModel extends BaseViewModel<Never> {
   static const int readingCountPerRow = 4;
-  static const int calibrationRowCount = 2;
+  static const int calibrationRowCount = 1;
   static const int wavelengthGroupCount = 2;
   static const int wavelengthRowCount = 2;
-  static const List<int> calibrationOrders = <int>[2, 2];
+  static const List<int> calibrationOrders = <int>[2];
   static const List<int> wavelengthOrders = <int>[1, 2];
   static const double defaultCalibrationReferenceWavelengthNm = 546.07;
   static const double nmToMm = 1e-6;
 
   static const List<List<String>> defaultCalibrationPreset = <List<String>>[
-    <String>['153 03', '333 03', '191 07', '11 07'],
-    <String>['156 20', '336 20', '194 24', '14 24'],
+    <String>['159 03', '339 03', '197 34', '17 34'],
   ];
 
   static const List<List<List<String>>> defaultWavelengthPresets =
@@ -210,11 +209,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       );
     }
 
-    final double averageGratingConstantMm = rows
-            .map((DiffractionGratingCalibrationRowResult row) =>
-                row.gratingConstantMm)
-            .reduce((double a, double b) => a + b) /
-        rows.length;
+    final double averageGratingConstantMm = rows.first.gratingConstantMm;
     return DiffractionGratingCalibrationResult(
       referenceWavelengthNm: referenceNm,
       rows: List<DiffractionGratingCalibrationRowResult>.unmodifiable(rows),

--- a/lib/features/physics_lab/features/diffraction_grating/views/diffraction_grating_view.dart
+++ b/lib/features/physics_lab/features/diffraction_grating/views/diffraction_grating_view.dart
@@ -120,15 +120,12 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
             padding: const EdgeInsets.all(6),
             children: [
               _InfoCard(
-                title: l10n.physicsLabDiffractionGratingIntroTitle,
-                child: Text(l10n.physicsLabDiffractionGratingDescription),
-              ),
-              const SizedBox(height: 8),
-              _InfoCard(
                 title: l10n.physicsLabDiffractionGratingFormulaTitle,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    Text(l10n.physicsLabDiffractionGratingDescription),
+                    const SizedBox(height: 8),
                     Text(l10n.physicsLabDiffractionGratingFormulaBody),
                     const SizedBox(height: 8),
                     const PhysicsLabFormula.block(
@@ -173,6 +170,12 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
     AppLocalizations l10n,
     DiffractionGratingCalibrationResult? result,
   ) {
+    final _MeasurementRowCardResult? rowResult = result == null
+        ? null
+        : _buildCalibrationRowCardResult(
+            l10n: l10n,
+            rowResult: result.rows.first,
+          );
     return Card(
       elevation: 0,
       child: Padding(
@@ -181,7 +184,7 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l10n.physicsLabDiffractionGratingCalibrationSectionTitle,
+              l10n.physicsLabDiffractionGratingWavelengthSectionTitle(1),
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 8),
@@ -192,6 +195,7 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
                   ),
             ),
             const SizedBox(height: 8),
+            // 输入校准参考波长
             _NumericTextField(
               controller: _calibrationReferenceController,
               label: l10n.physicsLabDiffractionGratingCalibrationReferenceLabel,
@@ -199,38 +203,18 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
               onChanged: _viewModel.updateCalibrationReferenceText,
             ),
             const SizedBox(height: 8),
-            for (int rowIndex = 0;
-                rowIndex < DiffractionGratingViewModel.calibrationRowCount;
-                rowIndex += 1)
-              Padding(
-                padding: EdgeInsets.only(
-                  bottom: rowIndex + 1 ==
-                          DiffractionGratingViewModel.calibrationRowCount
-                      ? 0
-                      : 8,
-                ),
-                child: _MeasurementRowCard(
-                  title: l10n.physicsLabDiffractionGratingCalibrationRowTitle(
-                    rowIndex + 1,
-                    DiffractionGratingViewModel.calibrationOrders[rowIndex],
-                  ),
-                  controllers: _calibrationControllers[rowIndex],
-                  labels: _readingLabels(l10n),
-                  onChanged: (int readingIndex, String value) {
-                    _viewModel.updateCalibrationReading(
-                      rowIndex,
-                      readingIndex,
-                      value,
-                    );
-                  },
-                  result: result == null
-                      ? null
-                      : _buildCalibrationRowCardResult(
-                          l10n: l10n,
-                          rowResult: result.rows[rowIndex],
-                        ),
-                ),
+            _MeasurementRowCard(
+              title: l10n.physicsLabDiffractionGratingWavelengthRowTitle(
+                DiffractionGratingViewModel.calibrationOrders.first,
               ),
+              controllers: _calibrationControllers.first,
+              labels: _readingLabelTexes(),
+              onChanged: (int readingIndex, String value) {
+                _viewModel.updateCalibrationReading(0, readingIndex, value);
+              },
+              result: rowResult,
+              showPrimaryBadge: false,
+            ),
             const Divider(height: 20),
             if (result == null)
               Text(
@@ -314,7 +298,7 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
                     DiffractionGratingViewModel.wavelengthOrders[rowIndex],
                   ),
                   controllers: _groupControllers[groupIndex][rowIndex],
-                  labels: _readingLabels(l10n),
+                  labels: _readingLabelTexes(),
                   onChanged: (int readingIndex, String value) {
                     _viewModel.updateWavelengthReading(
                       groupIndex,
@@ -369,12 +353,12 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
     );
   }
 
-  List<String> _readingLabels(AppLocalizations l10n) {
-    return <String>[
-      l10n.physicsLabDiffractionGratingReadingLabel(1),
-      l10n.physicsLabDiffractionGratingReadingPrimeLabel(1),
-      l10n.physicsLabDiffractionGratingReadingLabel(2),
-      l10n.physicsLabDiffractionGratingReadingPrimeLabel(2),
+  List<String> _readingLabelTexes() {
+    return const <String>[
+      r'\psi_1',
+      r"\psi_1^{\prime}",
+      r'\psi_2',
+      r"\psi_2^{\prime}",
     ];
   }
 
@@ -483,6 +467,7 @@ class _MeasurementRowCard extends StatelessWidget {
     required this.labels,
     required this.onChanged,
     required this.result,
+    this.showPrimaryBadge = true,
   });
 
   final String title;
@@ -490,6 +475,7 @@ class _MeasurementRowCard extends StatelessWidget {
   final List<String> labels;
   final void Function(int readingIndex, String value) onChanged;
   final _MeasurementRowCardResult? result;
+  final bool showPrimaryBadge;
 
   @override
   Widget build(BuildContext context) {
@@ -521,7 +507,7 @@ class _MeasurementRowCard extends StatelessWidget {
             itemBuilder: (BuildContext context, int index) {
               return _AngleInputField(
                 controllers: controllers[index],
-                label: labels[index],
+                labelTex: labels[index],
                 onChanged: (String value) => onChanged(index, value),
               );
             },
@@ -532,11 +518,13 @@ class _MeasurementRowCard extends StatelessWidget {
               spacing: 8,
               runSpacing: 6,
               children: [
-                _SummaryBadge(
-                  label:
-                      PhysicsLabFormula.inline(tex: result!.primaryFormulaTex),
-                  value: result!.primaryValueText,
-                ),
+                if (showPrimaryBadge)
+                  _SummaryBadge(
+                    label: PhysicsLabFormula.inline(
+                      tex: result!.primaryFormulaTex,
+                    ),
+                    value: result!.primaryValueText,
+                  ),
                 if (result!.secondaryLabelText != null &&
                     result!.secondaryValueText != null)
                   _SummaryBadge(
@@ -672,59 +660,100 @@ String _formatDegreeText(double value) {
   );
 }
 
-class _AngleInputField extends StatelessWidget {
+class _AngleInputField extends StatefulWidget {
   const _AngleInputField({
     required this.controllers,
-    required this.label,
+    required this.labelTex,
     required this.onChanged,
   });
 
   final _AngleFieldControllers controllers;
-  final String label;
+  final String labelTex;
   final ValueChanged<String> onChanged;
 
   @override
+  State<_AngleInputField> createState() => _AngleInputFieldState();
+}
+
+class _AngleInputFieldState extends State<_AngleInputField> {
+  late final FocusNode _degreeFocusNode;
+  late final FocusNode _minuteFocusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _degreeFocusNode = FocusNode()..addListener(_handleFocusChanged);
+    _minuteFocusNode = FocusNode()..addListener(_handleFocusChanged);
+  }
+
+  @override
+  void dispose() {
+    _degreeFocusNode
+      ..removeListener(_handleFocusChanged)
+      ..dispose();
+    _minuteFocusNode
+      ..removeListener(_handleFocusChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _handleFocusChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline,
+    final AppLocalizations l10n = AppLocalizations.of(context);
+    final bool isFocused =
+        _degreeFocusNode.hasFocus || _minuteFocusNode.hasFocus;
+    final bool isEmpty = widget.controllers.degreeController.text.trim().isEmpty &&
+        widget.controllers.minuteController.text.trim().isEmpty;
+    return InputDecorator(
+      isFocused: isFocused,
+      isEmpty: isEmpty,
+      decoration: InputDecoration(
+        border: const OutlineInputBorder(),
+        isDense: true,
+        label: PhysicsLabFormula.inline(
+          tex: widget.labelTex,
         ),
-        borderRadius: BorderRadius.circular(12),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 12,
+          vertical: 10,
+        ),
       ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        child: Row(
-          children: [
-            SizedBox(
-              width: 34,
-              child: Text(
-                label,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
+      child: Row(
+        children: [
+          Expanded(
+            child: _AnglePartField(
+              controller: widget.controllers.degreeController,
+              focusNode: _degreeFocusNode,
+              hintText: l10n.physicsLabDiffractionGratingDegreeHint,
+              onChanged: (_) => widget.onChanged(widget.controllers.combinedText),
             ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: _AnglePartField(
-                controller: controllers.degreeController,
-                hintText: '',
-                onChanged: (_) => onChanged(controllers.combinedText),
-              ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            _degreeSymbol,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: _AnglePartField(
+              controller: widget.controllers.minuteController,
+              focusNode: _minuteFocusNode,
+              hintText: l10n.physicsLabDiffractionGratingMinuteHint,
+              onChanged: (_) => widget.onChanged(widget.controllers.combinedText),
             ),
-            const SizedBox(width: 6),
-            Text(_degreeSymbol),
-            const SizedBox(width: 6),
-            Expanded(
-              child: _AnglePartField(
-                controller: controllers.minuteController,
-                hintText: '',
-                onChanged: (_) => onChanged(controllers.combinedText),
-              ),
-            ),
-            const SizedBox(width: 4),
-            const Text('\''),
-          ],
-        ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            '\'',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
       ),
     );
   }
@@ -733,11 +762,13 @@ class _AngleInputField extends StatelessWidget {
 class _AnglePartField extends StatelessWidget {
   const _AnglePartField({
     required this.controller,
+    required this.focusNode,
     required this.hintText,
     required this.onChanged,
   });
 
   final TextEditingController controller;
+  final FocusNode focusNode;
   final String hintText;
   final ValueChanged<String> onChanged;
 
@@ -745,6 +776,8 @@ class _AnglePartField extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextField(
       controller: controller,
+      focusNode: focusNode,
+      textAlign: TextAlign.end,
       keyboardType: const TextInputType.numberWithOptions(
         decimal: false,
         signed: false,
@@ -757,6 +790,9 @@ class _AnglePartField extends StatelessWidget {
         hintText: hintText,
         border: InputBorder.none,
         contentPadding: EdgeInsets.zero,
+        hintStyle: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
       ),
       onChanged: onChanged,
     );

--- a/lib/features/physics_lab/features/diffraction_grating/views/diffraction_grating_view.dart
+++ b/lib/features/physics_lab/features/diffraction_grating/views/diffraction_grating_view.dart
@@ -855,8 +855,8 @@ class _SummaryBadge extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          DefaultTextStyle(
-            style: Theme.of(context).textTheme.labelMedium!,
+          DefaultTextStyle.merge(
+            style: Theme.of(context).textTheme.labelMedium,
             child: label,
           ),
           const SizedBox(height: 1),

--- a/lib/features/physics_lab/features/diffraction_grating/views/diffraction_grating_view.dart
+++ b/lib/features/physics_lab/features/diffraction_grating/views/diffraction_grating_view.dart
@@ -4,7 +4,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:onetj/features/physics_lab/features/diffraction_grating/models/diffraction_grating_angle.dart';
 import 'package:onetj/features/physics_lab/features/diffraction_grating/models/diffraction_grating_calibration_result.dart';
-import 'package:onetj/features/physics_lab/features/diffraction_grating/models/diffraction_grating_measurement_result.dart';
 import 'package:onetj/features/physics_lab/features/diffraction_grating/models/diffraction_grating_wavelength_result.dart';
 import 'package:onetj/features/physics_lab/features/diffraction_grating/view_models/diffraction_grating_view_model.dart';
 import 'package:onetj/features/physics_lab/widgets/physics_lab_formula.dart';
@@ -97,6 +96,8 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
       builder: (BuildContext context, _) {
         final DiffractionGratingCalibrationResult? calibrationResult =
             _viewModel.calibrationResult;
+        final List<List<DiffractionGratingWavelengthRowResult?>>
+            wavelengthRowResults = _viewModel.wavelengthRowResults;
         final List<DiffractionGratingWavelengthGroupResult?> wavelengthResults =
             _viewModel.wavelengthResults;
         return Scaffold(
@@ -151,12 +152,14 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
               _buildWavelengthGroupCard(
                 l10n: l10n,
                 groupIndex: 0,
+                rowResults: wavelengthRowResults[0],
                 result: wavelengthResults[0],
               ),
               const SizedBox(height: 8),
               _buildWavelengthGroupCard(
                 l10n: l10n,
                 groupIndex: 1,
+                rowResults: wavelengthRowResults[1],
                 result: wavelengthResults[1],
               ),
             ],
@@ -220,13 +223,11 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
                       value,
                     );
                   },
-                  result: result?.rows[rowIndex].measurement,
-                  trailingValue: result == null
+                  result: result == null
                       ? null
-                      : _buildResultChip(
-                          label: 'd',
-                          value:
-                              '${_formatMillimeter(result.rows[rowIndex].gratingConstantMm)} ${l10n.physicsLabMichelsonMillimeterUnit}',
+                      : _buildCalibrationRowCardResult(
+                          l10n: l10n,
+                          rowResult: result.rows[rowIndex],
                         ),
                 ),
               ),
@@ -255,6 +256,7 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
   Widget _buildWavelengthGroupCard({
     required AppLocalizations l10n,
     required int groupIndex,
+    required List<DiffractionGratingWavelengthRowResult?> rowResults,
     required DiffractionGratingWavelengthGroupResult? result,
   }) {
     final DiffractionGratingCalibrationResult? calibrationResult =
@@ -321,13 +323,11 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
                       value,
                     );
                   },
-                  result: result?.rows[rowIndex].measurement,
-                  trailingValue: result == null
+                  result: rowResults[rowIndex] == null
                       ? null
-                      : _buildResultChip(
-                          label: r'\lambda',
-                          value:
-                              '${_formatNanometer(result.rows[rowIndex].wavelengthNm)} ${l10n.physicsLabMichelsonNanometerUnit}',
+                      : _buildWavelengthRowCardResult(
+                          l10n: l10n,
+                          rowResult: rowResults[rowIndex]!,
                         ),
                 ),
               ),
@@ -376,27 +376,6 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
       l10n.physicsLabDiffractionGratingReadingLabel(2),
       l10n.physicsLabDiffractionGratingReadingPrimeLabel(2),
     ];
-  }
-
-  Widget _buildResultChip({
-    required String label,
-    required String value,
-  }) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          PhysicsLabFormula.inline(tex: label),
-          const SizedBox(width: 4),
-          Text(value),
-        ],
-      ),
-    );
   }
 
   void _clearAllInputs() {
@@ -452,6 +431,38 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
     }
   }
 
+  _MeasurementRowCardResult _buildCalibrationRowCardResult({
+    required AppLocalizations l10n,
+    required DiffractionGratingCalibrationRowResult rowResult,
+  }) {
+    return _MeasurementRowCardResult(
+      firstDifferenceDegrees: rowResult.measurement.firstDifferenceDegrees,
+      secondDifferenceDegrees: rowResult.measurement.secondDifferenceDegrees,
+      gammaDegrees: rowResult.measurement.gammaDegrees,
+      sinGamma: rowResult.measurement.sinGamma,
+      primaryFormulaTex: 'd',
+      primaryValueText:
+          '${_formatMillimeter(rowResult.gratingConstantMm)} ${l10n.physicsLabMichelsonMillimeterUnit}',
+    );
+  }
+
+  _MeasurementRowCardResult _buildWavelengthRowCardResult({
+    required AppLocalizations l10n,
+    required DiffractionGratingWavelengthRowResult rowResult,
+  }) {
+    return _MeasurementRowCardResult(
+      firstDifferenceDegrees: rowResult.measurement.firstDifferenceDegrees,
+      secondDifferenceDegrees: rowResult.measurement.secondDifferenceDegrees,
+      gammaDegrees: rowResult.measurement.gammaDegrees,
+      sinGamma: rowResult.measurement.sinGamma,
+      primaryFormulaTex: r'\lambda',
+      primaryValueText:
+          '${_formatNanometer(rowResult.wavelengthNm)} ${l10n.physicsLabMichelsonNanometerUnit}',
+      secondaryLabelText: l10n.physicsLabMichelsonRelativeErrorLabel,
+      secondaryValueText: '${_formatPercent(rowResult.relativeErrorPercent)}%',
+    );
+  }
+
   String _formatMillimeter(double value) {
     return value.toStringAsFixed(6);
   }
@@ -472,15 +483,13 @@ class _MeasurementRowCard extends StatelessWidget {
     required this.labels,
     required this.onChanged,
     required this.result,
-    this.trailingValue,
   });
 
   final String title;
   final List<_AngleFieldControllers> controllers;
   final List<String> labels;
   final void Function(int readingIndex, String value) onChanged;
-  final DiffractionGratingMeasurementResult? result;
-  final Widget? trailingValue;
+  final _MeasurementRowCardResult? result;
 
   @override
   Widget build(BuildContext context) {
@@ -494,17 +503,9 @@ class _MeasurementRowCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: Text(
-                  title,
-                  style: Theme.of(context).textTheme.titleSmall,
-                ),
-              ),
-              if (trailingValue != null) trailingValue!,
-            ],
+          Text(
+            title,
+            style: Theme.of(context).textTheme.titleSmall,
           ),
           const SizedBox(height: 8),
           GridView.builder(
@@ -532,19 +533,38 @@ class _MeasurementRowCard extends StatelessWidget {
               runSpacing: 6,
               children: [
                 _SummaryBadge(
-                  label: l10n.physicsLabDiffractionGratingDifferenceOneLabel,
-                  value: _formatDegreeText(result!.firstDifferenceDegrees),
+                  label:
+                      PhysicsLabFormula.inline(tex: result!.primaryFormulaTex),
+                  value: result!.primaryValueText,
+                ),
+                if (result!.secondaryLabelText != null &&
+                    result!.secondaryValueText != null)
+                  _SummaryBadge(
+                    label: Text(result!.secondaryLabelText!),
+                    value: result!.secondaryValueText!,
+                  ),
+                _SummaryBadge(
+                  label: Text(
+                    l10n.physicsLabDiffractionGratingDifferenceOneLabel,
+                  ),
+                  value: _formatDegreeText(
+                    result!.firstDifferenceDegrees,
+                  ),
                 ),
                 _SummaryBadge(
-                  label: l10n.physicsLabDiffractionGratingDifferenceTwoLabel,
-                  value: _formatDegreeText(result!.secondDifferenceDegrees),
+                  label: Text(
+                    l10n.physicsLabDiffractionGratingDifferenceTwoLabel,
+                  ),
+                  value: _formatDegreeText(
+                    result!.secondDifferenceDegrees,
+                  ),
                 ),
                 _SummaryBadge(
-                  label: l10n.physicsLabDiffractionGratingGammaLabel,
+                  label: Text(l10n.physicsLabDiffractionGratingGammaLabel),
                   value: _formatDegreeText(result!.gammaDegrees),
                 ),
                 _SummaryBadge(
-                  label: l10n.physicsLabDiffractionGratingSinGammaLabel,
+                  label: Text(l10n.physicsLabDiffractionGratingSinGammaLabel),
                   value: result!.sinGamma.toStringAsFixed(4),
                 ),
               ],
@@ -554,6 +574,28 @@ class _MeasurementRowCard extends StatelessWidget {
       ),
     );
   }
+}
+
+class _MeasurementRowCardResult {
+  const _MeasurementRowCardResult({
+    required this.firstDifferenceDegrees,
+    required this.secondDifferenceDegrees,
+    required this.gammaDegrees,
+    required this.sinGamma,
+    required this.primaryFormulaTex,
+    required this.primaryValueText,
+    this.secondaryLabelText,
+    this.secondaryValueText,
+  });
+
+  final double firstDifferenceDegrees;
+  final double secondDifferenceDegrees;
+  final double gammaDegrees;
+  final double sinGamma;
+  final String primaryFormulaTex;
+  final String primaryValueText;
+  final String? secondaryLabelText;
+  final String? secondaryValueText;
 }
 
 class _AngleFieldControllers {
@@ -643,7 +685,6 @@ class _AngleInputField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations l10n = AppLocalizations.of(context);
     return DecoratedBox(
       decoration: BoxDecoration(
         border: Border.all(
@@ -666,7 +707,7 @@ class _AngleInputField extends StatelessWidget {
             Expanded(
               child: _AnglePartField(
                 controller: controllers.degreeController,
-                hintText: l10n.physicsLabDiffractionGratingDegreeHint,
+                hintText: '',
                 onChanged: (_) => onChanged(controllers.combinedText),
               ),
             ),
@@ -676,7 +717,7 @@ class _AngleInputField extends StatelessWidget {
             Expanded(
               child: _AnglePartField(
                 controller: controllers.minuteController,
-                hintText: l10n.physicsLabDiffractionGratingMinuteHint,
+                hintText: '',
                 onChanged: (_) => onChanged(controllers.combinedText),
               ),
             ),
@@ -763,7 +804,7 @@ class _SummaryBadge extends StatelessWidget {
     required this.value,
   });
 
-  final String label;
+  final Widget label;
   final String value;
 
   @override
@@ -778,9 +819,9 @@ class _SummaryBadge extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(
-            label,
-            style: Theme.of(context).textTheme.labelMedium,
+          DefaultTextStyle(
+            style: Theme.of(context).textTheme.labelMedium!,
+            child: label,
           ),
           const SizedBox(height: 1),
           Text(value),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -83,9 +83,9 @@
   "physicsLabDiffractionGratingFormulaTitle": "Formula",
   "physicsLabDiffractionGratingFormulaBody": "For each record, compute two angle differences from the four raw readings, add them, divide by 4 to get γ, then use d = kλ₀/sinγ for the first section and λ = dsinγ/k for the second and third sections. Each wavelength section averages its two rows and compares the result against the entered reference wavelength.",
   "physicsLabDiffractionGratingCalibrationSectionTitle": "Section 1: Solve for d",
-  "physicsLabDiffractionGratingCalibrationHint": "This section uses two fixed ±2 order rows to derive the average grating constant. The calibration wavelength can be edited directly.",
+  "physicsLabDiffractionGratingCalibrationHint": "This section uses one ±2 order record to calculate the grating constant d. The calibration wavelength can be edited directly.",
   "physicsLabDiffractionGratingCalibrationReferenceLabel": "Calibration wavelength",
-  "physicsLabDiffractionGratingCalibrationRowTitle": "Record {index} (k = ±{order})",
+  "physicsLabDiffractionGratingCalibrationRowTitle": "Measurement {index} (k = ±{order})",
   "@physicsLabDiffractionGratingCalibrationRowTitle": {
     "placeholders": {
       "index": {
@@ -96,7 +96,7 @@
       }
     }
   },
-  "physicsLabDiffractionGratingAverageGratingConstantLabel": "Average Grating Constant",
+  "physicsLabDiffractionGratingAverageGratingConstantLabel": "Grating Constant d",
   "physicsLabDiffractionGratingCalibrationIncompleteHint": "Fill in all calibration readings and the calibration wavelength first.",
   "physicsLabDiffractionGratingWavelengthSectionTitle": "Section {group}: Solve for λ",
   "@physicsLabDiffractionGratingWavelengthSectionTitle": {
@@ -106,8 +106,8 @@
       }
     }
   },
-  "physicsLabDiffractionGratingWavelengthHint": "Each section uses fixed ±1 and ±2 order rows and automatically reuses the average d from section 1.",
-  "physicsLabDiffractionGratingInheritedGratingConstant": "Inherited Average d",
+  "physicsLabDiffractionGratingWavelengthHint": "Each section uses fixed ±1 and ±2 order rows and automatically reuses the d from section 1.",
+  "physicsLabDiffractionGratingInheritedGratingConstant": "Inherited d",
   "physicsLabDiffractionGratingReferenceLabel": "Reference Wavelength",
   "physicsLabDiffractionGratingWavelengthRowTitle": "k = ±{order}",
   "@physicsLabDiffractionGratingWavelengthRowTitle": {
@@ -119,7 +119,7 @@
   },
   "physicsLabDiffractionGratingAverageWavelengthLabel": "Average Wavelength",
   "physicsLabDiffractionGratingWavelengthIncompleteHint": "Fill in all readings and the reference wavelength for this section first.",
-  "physicsLabDiffractionGratingNeedCalibrationHint": "Complete section 1 and obtain a valid average d first.",
+  "physicsLabDiffractionGratingNeedCalibrationHint": "Complete section 1 and obtain a valid d first.",
   "physicsLabDiffractionGratingReadingLabel": "ψ{index}",
   "@physicsLabDiffractionGratingReadingLabel": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -82,23 +82,11 @@
   "physicsLabDiffractionGratingIntroTitle": "Experiment",
   "physicsLabDiffractionGratingFormulaTitle": "Formula",
   "physicsLabDiffractionGratingFormulaBody": "For each record, compute two angle differences from the four raw readings, add them, divide by 4 to get γ, then use d = kλ₀/sinγ for the first section and λ = dsinγ/k for the second and third sections. Each wavelength section averages its two rows and compares the result against the entered reference wavelength.",
-  "physicsLabDiffractionGratingCalibrationSectionTitle": "Section 1: Solve for d",
-  "physicsLabDiffractionGratingCalibrationHint": "This section uses one ±2 order record to calculate the grating constant d. The calibration wavelength can be edited directly.",
+  "physicsLabDiffractionGratingCalibrationHint": "With the mercury yellow line wavelength known, this section uses the k = ±2 readings to calculate the grating constant d.",
   "physicsLabDiffractionGratingCalibrationReferenceLabel": "Calibration wavelength",
-  "physicsLabDiffractionGratingCalibrationRowTitle": "Measurement {index} (k = ±{order})",
-  "@physicsLabDiffractionGratingCalibrationRowTitle": {
-    "placeholders": {
-      "index": {
-        "type": "int"
-      },
-      "order": {
-        "type": "int"
-      }
-    }
-  },
   "physicsLabDiffractionGratingAverageGratingConstantLabel": "Grating Constant d",
   "physicsLabDiffractionGratingCalibrationIncompleteHint": "Fill in all calibration readings and the calibration wavelength first.",
-  "physicsLabDiffractionGratingWavelengthSectionTitle": "Section {group}: Solve for λ",
+  "physicsLabDiffractionGratingWavelengthSectionTitle": "Group {group}",
   "@physicsLabDiffractionGratingWavelengthSectionTitle": {
     "placeholders": {
       "group": {
@@ -120,22 +108,6 @@
   "physicsLabDiffractionGratingAverageWavelengthLabel": "Average Wavelength",
   "physicsLabDiffractionGratingWavelengthIncompleteHint": "Fill in all readings and the reference wavelength for this section first.",
   "physicsLabDiffractionGratingNeedCalibrationHint": "Complete section 1 and obtain a valid d first.",
-  "physicsLabDiffractionGratingReadingLabel": "ψ{index}",
-  "@physicsLabDiffractionGratingReadingLabel": {
-    "placeholders": {
-      "index": {
-        "type": "int"
-      }
-    }
-  },
-  "physicsLabDiffractionGratingReadingPrimeLabel": "ψ{index}'",
-  "@physicsLabDiffractionGratingReadingPrimeLabel": {
-    "placeholders": {
-      "index": {
-        "type": "int"
-      }
-    }
-  },
   "physicsLabDiffractionGratingDifferenceOneLabel": "|ψ2 - ψ1|",
   "physicsLabDiffractionGratingDifferenceTwoLabel": "|ψ2' - ψ1'|",
   "physicsLabDiffractionGratingGammaLabel": "γ",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -83,23 +83,11 @@
     "physicsLabDiffractionGratingIntroTitle": "实验说明",
     "physicsLabDiffractionGratingFormulaTitle": "计算规则",
     "physicsLabDiffractionGratingFormulaBody": "对每条记录，先由两组原始读数分别求角差，再将两组角差相加后除以 4 得到 γ，之后按首组 d = kλ₀/sinγ、后两组 λ = dsinγ/k 计算。第二组和第三组各自使用组内两条记录求平均波长，并和填写的参考值比较相对误差。",
-    "physicsLabDiffractionGratingCalibrationSectionTitle": "第一组：求光栅常数 d",
-    "physicsLabDiffractionGratingCalibrationHint": "本组使用一条 ±2 级记录计算光栅常数 d，校准参考波长可直接修改。",
+    "physicsLabDiffractionGratingCalibrationHint": "已知汞黄线波长后，本组用 k = ±2 的读数计算光栅常数 d。",
     "physicsLabDiffractionGratingCalibrationReferenceLabel": "校准参考波长",
-    "physicsLabDiffractionGratingCalibrationRowTitle": "第 {index} 次测量（k = ±{order}）",
-    "@physicsLabDiffractionGratingCalibrationRowTitle": {
-      "placeholders": {
-        "index": {
-          "type": "int"
-        },
-        "order": {
-          "type": "int"
-        }
-      }
-    },
     "physicsLabDiffractionGratingAverageGratingConstantLabel": "光栅常数 d",
     "physicsLabDiffractionGratingCalibrationIncompleteHint": "请先填写完整的首组原始读数和校准参考波长。",
-    "physicsLabDiffractionGratingWavelengthSectionTitle": "第 {group} 组：求波长",
+    "physicsLabDiffractionGratingWavelengthSectionTitle": "第 {group} 组",
     "@physicsLabDiffractionGratingWavelengthSectionTitle": {
       "placeholders": {
         "group": {
@@ -121,22 +109,6 @@
     "physicsLabDiffractionGratingAverageWavelengthLabel": "平均波长",
     "physicsLabDiffractionGratingWavelengthIncompleteHint": "请先填写完整的原始读数和本组参考波长。",
     "physicsLabDiffractionGratingNeedCalibrationHint": "请先完成第一组并得到有效的 d。",
-    "physicsLabDiffractionGratingReadingLabel": "ψ{index}",
-    "@physicsLabDiffractionGratingReadingLabel": {
-      "placeholders": {
-        "index": {
-          "type": "int"
-        }
-      }
-    },
-    "physicsLabDiffractionGratingReadingPrimeLabel": "ψ{index}'",
-    "@physicsLabDiffractionGratingReadingPrimeLabel": {
-      "placeholders": {
-        "index": {
-          "type": "int"
-        }
-      }
-    },
     "physicsLabDiffractionGratingDifferenceOneLabel": "|ψ₂ - ψ₁|",
     "physicsLabDiffractionGratingDifferenceTwoLabel": "|ψ₂' - ψ₁'|",
     "physicsLabDiffractionGratingGammaLabel": "γ",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -84,9 +84,9 @@
     "physicsLabDiffractionGratingFormulaTitle": "计算规则",
     "physicsLabDiffractionGratingFormulaBody": "对每条记录，先由两组原始读数分别求角差，再将两组角差相加后除以 4 得到 γ，之后按首组 d = kλ₀/sinγ、后两组 λ = dsinγ/k 计算。第二组和第三组各自使用组内两条记录求平均波长，并和填写的参考值比较相对误差。",
     "physicsLabDiffractionGratingCalibrationSectionTitle": "第一组：求光栅常数 d",
-    "physicsLabDiffractionGratingCalibrationHint": "默认按两条 ±2 级记录求平均 d，校准参考波长可直接修改。",
+    "physicsLabDiffractionGratingCalibrationHint": "本组使用一条 ±2 级记录计算光栅常数 d，校准参考波长可直接修改。",
     "physicsLabDiffractionGratingCalibrationReferenceLabel": "校准参考波长",
-    "physicsLabDiffractionGratingCalibrationRowTitle": "记录 {index}（k = ±{order}）",
+    "physicsLabDiffractionGratingCalibrationRowTitle": "第 {index} 次测量（k = ±{order}）",
     "@physicsLabDiffractionGratingCalibrationRowTitle": {
       "placeholders": {
         "index": {
@@ -97,7 +97,7 @@
         }
       }
     },
-    "physicsLabDiffractionGratingAverageGratingConstantLabel": "平均光栅常数",
+    "physicsLabDiffractionGratingAverageGratingConstantLabel": "光栅常数 d",
     "physicsLabDiffractionGratingCalibrationIncompleteHint": "请先填写完整的首组原始读数和校准参考波长。",
     "physicsLabDiffractionGratingWavelengthSectionTitle": "第 {group} 组：求波长",
     "@physicsLabDiffractionGratingWavelengthSectionTitle": {
@@ -107,8 +107,8 @@
         }
       }
     },
-    "physicsLabDiffractionGratingWavelengthHint": "本组固定使用 ±1 和 ±2 两条记录，并自动引用第一组的平均 d。",
-    "physicsLabDiffractionGratingInheritedGratingConstant": "继承的平均 d",
+    "physicsLabDiffractionGratingWavelengthHint": "本组固定使用 ±1 和 ±2 两条记录，并自动引用第一组求出的 d。",
+    "physicsLabDiffractionGratingInheritedGratingConstant": "继承的 d",
     "physicsLabDiffractionGratingReferenceLabel": "参考波长",
     "physicsLabDiffractionGratingWavelengthRowTitle": "k = ±{order}",
     "@physicsLabDiffractionGratingWavelengthRowTitle": {
@@ -120,7 +120,7 @@
     },
     "physicsLabDiffractionGratingAverageWavelengthLabel": "平均波长",
     "physicsLabDiffractionGratingWavelengthIncompleteHint": "请先填写完整的原始读数和本组参考波长。",
-    "physicsLabDiffractionGratingNeedCalibrationHint": "请先完成第一组并得到有效的平均 d。",
+    "physicsLabDiffractionGratingNeedCalibrationHint": "请先完成第一组并得到有效的 d。",
     "physicsLabDiffractionGratingReadingLabel": "ψ{index}",
     "@physicsLabDiffractionGratingReadingLabel": {
       "placeholders": {

--- a/ohos/AppScope/app.json5
+++ b/ohos/AppScope/app.json5
@@ -2,8 +2,8 @@
   "app": {
     "bundleName": "com.oierxjn.onetj",
     "vendor": "tongji",
-    "versionCode": 2004003,
-    "versionName": "2.4.3",
+    "versionCode": 2004004,
+    "versionName": "2.4.4",
     "icon": "$media:layered_image",
     "label": "$string:app_name"
   }

--- a/ohos/AppScope/resources/base/element/string.json
+++ b/ohos/AppScope/resources/base/element/string.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "app_version",
-      "value": "2.4.3"
+      "value": "2.4.4"
     }
   ]
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.4.3+15
+version: 2.4.4+16
 
 environment:
   sdk: ^3.6.2

--- a/setup.iss
+++ b/setup.iss
@@ -1,7 +1,7 @@
 [Setup]
 AppId={{e52df8a9-9166-40d9-ad95-a4d5880b9a0f}}
 AppName=OneTJ
-AppVersion=2.4.3
+AppVersion=2.4.4
 DefaultDirName={localappdata}\Programs\OneTJ
 DefaultGroupName=OneTJ
 OutputDir=dist

--- a/test/features/physics_lab/diffraction_grating_view_model_test.dart
+++ b/test/features/physics_lab/diffraction_grating_view_model_test.dart
@@ -10,10 +10,10 @@ void main() {
 
       viewModel.updateCalibrationReferenceText('546.07');
       _fillRow(viewModel.updateCalibrationReading, 0, <String>[
-        '153 03',
-        '333 03',
-        '191 07',
-        '11 07',
+        '159 03',
+        '339 03',
+        '197 34',
+        '17 34',
       ]);
       viewModel.updateReferenceWavelengthText(0, '435.84');
       _fillGroupRow(viewModel, 0, 0, <String>[
@@ -53,25 +53,25 @@ void main() {
       expect(calibration!.rows, hasLength(1));
       expect(
         calibration.rows.first.measurement.firstDifferenceDegrees,
-        closeTo(38.0666666667, 1e-9),
+        closeTo(38.5166666667, 1e-9),
       );
       expect(
         calibration.averageGratingConstantMm,
-        closeTo(0.0033489086713, 1e-12),
+        closeTo(0.0033112414727, 1e-12),
       );
 
       expect(wavelengthResults[0], isNotNull);
       expect(
         wavelengthResults[0]!.rows.first.wavelengthNm,
-        closeTo(439.0518708503, 1e-9),
+        closeTo(434.1135892658, 1e-9),
       );
       expect(
         wavelengthResults[0]!.averageWavelengthNm,
-        closeTo(439.5078410093, 1e-9),
+        closeTo(434.5644308533, 1e-9),
       );
       expect(
         wavelengthResults[0]!.relativeErrorPercent,
-        closeTo(0.8415567661, 1e-9),
+        closeTo(0.2926691324, 1e-9),
       );
       expect(
         wavelengthRowResults[0].first!.wavelengthNm,
@@ -85,11 +85,11 @@ void main() {
       expect(wavelengthResults[1], isNotNull);
       expect(
         wavelengthResults[1]!.averageWavelengthNm,
-        closeTo(584.8953687025, 1e-9),
+        closeTo(578.3166972080, 1e-9),
       );
       expect(
         wavelengthResults[1]!.relativeErrorPercent,
-        closeTo(0.1782829808, 1e-9),
+        closeTo(1.3010381254, 1e-9),
       );
       expect(
         wavelengthRowResults[1].first!.wavelengthNm,
@@ -122,6 +122,44 @@ void main() {
 
       expect(viewModel.calibrationResult, isNull);
       expect(viewModel.wavelengthResults.first, isNull);
+
+      viewModel.dispose();
+    });
+
+    test('returns expected results for default preset', () {
+      final DiffractionGratingViewModel viewModel = DiffractionGratingViewModel();
+
+      viewModel.applyDefaultPreset();
+
+      final DiffractionGratingCalibrationResult? calibration =
+          viewModel.calibrationResult;
+      final List<DiffractionGratingWavelengthGroupResult?> wavelengthResults =
+          viewModel.wavelengthResults;
+
+      expect(calibration, isNotNull);
+      expect(
+        calibration!.averageGratingConstantMm,
+        closeTo(0.0033112414727, 1e-12),
+      );
+      expect(wavelengthResults, hasLength(2));
+      expect(wavelengthResults[0], isNotNull);
+      expect(
+        wavelengthResults[0]!.averageWavelengthNm,
+        closeTo(434.5644308533, 1e-9),
+      );
+      expect(
+        wavelengthResults[0]!.relativeErrorPercent,
+        closeTo(0.2926691324, 1e-9),
+      );
+      expect(wavelengthResults[1], isNotNull);
+      expect(
+        wavelengthResults[1]!.averageWavelengthNm,
+        closeTo(578.3166972080, 1e-9),
+      );
+      expect(
+        wavelengthResults[1]!.relativeErrorPercent,
+        closeTo(1.3010381254, 1e-9),
+      );
 
       viewModel.dispose();
     });

--- a/test/features/physics_lab/diffraction_grating_view_model_test.dart
+++ b/test/features/physics_lab/diffraction_grating_view_model_test.dart
@@ -15,12 +15,6 @@ void main() {
         '191 07',
         '11 07',
       ]);
-      _fillRow(viewModel.updateCalibrationReading, 1, <String>[
-        '156 20',
-        '336 20',
-        '194 24',
-        '14 24',
-      ]);
       viewModel.updateReferenceWavelengthText(0, '435.84');
       _fillGroupRow(viewModel, 0, 0, <String>[
         '171 02',
@@ -54,7 +48,7 @@ void main() {
           viewModel.wavelengthResults;
 
       expect(calibration, isNotNull);
-      expect(calibration!.rows, hasLength(2));
+      expect(calibration!.rows, hasLength(1));
       expect(
         calibration.rows.first.measurement.firstDifferenceDegrees,
         closeTo(38.0666666667, 1e-9),

--- a/test/features/physics_lab/diffraction_grating_view_model_test.dart
+++ b/test/features/physics_lab/diffraction_grating_view_model_test.dart
@@ -44,6 +44,8 @@ void main() {
 
       final DiffractionGratingCalibrationResult? calibration =
           viewModel.calibrationResult;
+      final List<List<DiffractionGratingWavelengthRowResult?>>
+          wavelengthRowResults = viewModel.wavelengthRowResults;
       final List<DiffractionGratingWavelengthGroupResult?> wavelengthResults =
           viewModel.wavelengthResults;
 
@@ -71,6 +73,14 @@ void main() {
         wavelengthResults[0]!.relativeErrorPercent,
         closeTo(0.8415567661, 1e-9),
       );
+      expect(
+        wavelengthRowResults[0].first!.wavelengthNm,
+        closeTo(wavelengthResults[0]!.rows.first.wavelengthNm, 1e-9),
+      );
+      expect(
+        wavelengthRowResults[0][1]!.wavelengthNm,
+        closeTo(wavelengthResults[0]!.rows[1].wavelengthNm, 1e-9),
+      );
 
       expect(wavelengthResults[1], isNotNull);
       expect(
@@ -80,6 +90,14 @@ void main() {
       expect(
         wavelengthResults[1]!.relativeErrorPercent,
         closeTo(0.1782829808, 1e-9),
+      );
+      expect(
+        wavelengthRowResults[1].first!.wavelengthNm,
+        closeTo(wavelengthResults[1]!.rows.first.wavelengthNm, 1e-9),
+      );
+      expect(
+        wavelengthRowResults[1][1]!.wavelengthNm,
+        closeTo(wavelengthResults[1]!.rows[1].wavelengthNm, 1e-9),
       );
 
       viewModel.dispose();


### PR DESCRIPTION
This pull request refactors and enhances the diffraction grating experiment feature by simplifying calibration logic, improving result calculation and display, and clarifying the user interface. The main changes include reducing calibration rows, adding relative error calculations, and refactoring how results are built and presented.

**Calibration and Calculation Logic Updates:**

* Reduced the calibration process to use only one row instead of two, updating all related constants and default values in `DiffractionGratingViewModel` (`calibrationRowCount`, `calibrationOrders`, and `defaultCalibrationPreset`).
* Changed the calibration result calculation to use only the first row’s grating constant instead of averaging multiple rows.
* Refactored wavelength result building: extracted row result computation into `_buildWavelengthRowResult`, which now also calculates the relative error percentage for each wavelength measurement. [[1]](diffhunk://#diff-46ca677a3024902bfbf77604d055f6d3dc2d912de9860b451beea758087e5b4bR269-R309) [[2]](diffhunk://#diff-e837c97a208bd2ebdadf22abcb440b0f8794f100a55eebae46b6aeac85e4c7acR8-R14)
* Added a getter `wavelengthRowResults` for easier access to per-row results, improving separation of concerns and UI integration.

**User Interface Improvements:**

* Refactored the calibration and wavelength measurement cards to display only the relevant row, show detailed results (including relative error for wavelength), and use LaTeX-like labels for clarity. [[1]](diffhunk://#diff-bba395bcb03ff48b42faae52eb7a9f079fd23e3f52dc080e5906730a7e155002R152-R159) [[2]](diffhunk://#diff-bba395bcb03ff48b42faae52eb7a9f079fd23e3f52dc080e5906730a7e155002R198-R216) [[3]](diffhunk://#diff-bba395bcb03ff48b42faae52eb7a9f079fd23e3f52dc080e5906730a7e155002L324-R314) F5665eb5L415R415)
* Updated the formula and description section to improve information flow and readability.
* Changed reading labels to use LaTeX-style notation for consistency and clarity in the UI.

**Code Cleanup and Refactoring:**

* Removed now-unused methods and simplified result chip rendering, consolidating result display logic into `_buildCalibrationRowCardResult` and `_buildWavelengthRowCardResult`. ([lib/features/physics_lab/features/diffraction_grating/views/diffraction_grating_view.dartL372-L401](diffhunk://#diff-bba395bcb03ff48b42faae52eb7a9f079fd23e3f52dc080e5906730a7e155002L372-L401), F5665eb5L415R415)
* Updated widget parameters and signatures to support the new result structures and UI requirements. [[1]](diffhunk://#diff-bba395bcb03ff48b42faae52eb7a9f079fd23e3f52dc080e5906730a7e155002L475-R478) [[2]](diffhunk://#diff-bba395bcb03ff48b42faae52eb7a9f079fd23e3f52dc080e5906730a7e155002L497-L508)

These changes streamline the workflow for users, make the experiment results more informative, and improve code maintainability.