### PR TITLE
refactor: 依赖注入统一到 GetIt 容器

### DIFF
--- a/lib/app/di/dependencies.dart
+++ b/lib/app/di/dependencies.dart
@@ -2,6 +2,15 @@ import 'package:get_it/get_it.dart';
 
 import 'package:onetj/app/theme/theme_change_notifier.dart';
 import 'package:onetj/repo/app_update_state_repository.dart';
+import 'package:onetj/repo/color_preset_repository.dart';
+import 'package:onetj/repo/course_schedule_repository.dart';
+import 'package:onetj/repo/school_calendar_repository.dart';
+import 'package:onetj/repo/settings_repository.dart';
+import 'package:onetj/repo/student_info_repository.dart';
+import 'package:onetj/repo/template_repository.dart';
+import 'package:onetj/repo/theme_repository.dart';
+import 'package:onetj/repo/token_repository.dart';
+import 'package:onetj/repo/undergraduate_score_repository.dart';
 import 'package:onetj/services/app_update_api.dart';
 import 'package:onetj/services/app_update_service.dart';
 import 'package:onetj/services/external_launcher_service.dart';
@@ -9,43 +18,46 @@ import 'package:onetj/services/external_launcher_service.dart';
 final GetIt appLocator = GetIt.instance;
 
 void configureDependencies() {
-  // ThemeChangeNotifier
-  // 单例 —— 管理主题配色和深色模式
-  if (!appLocator.isRegistered<ThemeChangeNotifier>()) {
-    appLocator.registerLazySingleton<ThemeChangeNotifier>(
-      () => ThemeChangeNotifier(),
-    );
-  }
-  // AppUpdateStateRepository
-  // 单例
-  if (!appLocator.isRegistered<AppUpdateStateRepository>()) {
-    appLocator.registerLazySingleton<AppUpdateStateRepository>(
-      AppUpdateStateRepository.getInstance,
-    );
-  }
-  // AppUpdateApi
-  // 单例
-  if (!appLocator.isRegistered<AppUpdateApi>()) {
-    appLocator.registerLazySingleton<AppUpdateApi>(
-      AppUpdateApi.getInstance,
-    );
-  }
-  // AppUpdateService
-  // 单例
-  if (!appLocator.isRegistered<AppUpdateService>()) {
-    appLocator.registerLazySingleton<AppUpdateService>(
-      () => AppUpdateService(
-        api: appLocator<AppUpdateApi>(),
-        repository: appLocator<AppUpdateStateRepository>(),
-      ),
-    );
-  }
-  // ExternalLauncherService
-  if (!appLocator.isRegistered<ExternalLauncherService>()) {
-    appLocator.registerLazySingleton<ExternalLauncherService>(
-      ExternalLauncherService.getInstance,
-    );
-  }
+  // Repositories
+  appLocator.registerLazySingleton<TokenRepository>(TokenRepository.new);
+  appLocator.registerLazySingleton<SettingsRepository>(SettingsRepository.new);
+  appLocator.registerLazySingleton<ThemeRepository>(ThemeRepository.new);
+  appLocator.registerLazySingleton<ColorPresetRepository>(
+    ColorPresetRepository.new,
+  );
+  appLocator.registerLazySingleton<StudentInfoRepository>(
+    StudentInfoRepository.new,
+  );
+  appLocator.registerLazySingleton<SchoolCalendarRepository>(
+    SchoolCalendarRepository.new,
+  );
+  appLocator.registerLazySingleton<CourseScheduleRepository>(
+    CourseScheduleRepository.new,
+  );
+  appLocator.registerLazySingleton<UndergraduateScoreRepository>(
+    UndergraduateScoreRepository.new,
+  );
+  appLocator.registerLazySingleton<TemplateRepository>(TemplateRepository.new);
+  appLocator.registerLazySingleton<AppUpdateStateRepository>(
+    AppUpdateStateRepository.new,
+  );
+
+  // Services
+  appLocator.registerLazySingleton<AppUpdateApi>(AppUpdateApi.new);
+  appLocator.registerLazySingleton<AppUpdateService>(
+    () => AppUpdateService(
+      api: appLocator<AppUpdateApi>(),
+      repository: appLocator<AppUpdateStateRepository>(),
+    ),
+  );
+  appLocator.registerLazySingleton<ExternalLauncherService>(
+    ExternalLauncherService.new,
+  );
+
+  // Theme
+  appLocator.registerLazySingleton<ThemeChangeNotifier>(
+    ThemeChangeNotifier.new,
+  );
 }
 
 Future<void> resetDependencies() {

--- a/lib/app/theme/theme_change_notifier.dart
+++ b/lib/app/theme/theme_change_notifier.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/app/theme/theme_color_scheme_builder.dart';
 import 'package:onetj/models/theme_preferences.dart';
 import 'package:onetj/repo/theme_repository.dart';
@@ -13,7 +14,7 @@ import 'package:onetj/repo/theme_repository.dart';
 class ThemeChangeNotifier extends ChangeNotifier {
   ThemeChangeNotifier({
     ThemeRepository? repository,
-  }) : _repository = repository ?? ThemeRepository.getInstance() {
+  }) : _repository = repository ?? appLocator<ThemeRepository>() {
     // 监听 ThemeRepository 的变更，自动重建 ColorScheme
     _repository.addListener(_onPreferencesChanged);
     // 从当前缓存构建初始 ColorScheme

--- a/lib/features/app_update/view_models/app_update_migration_view_model.dart
+++ b/lib/features/app_update/view_models/app_update_migration_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/app/logging/logger.dart';
 import 'package:onetj/features/app_update/models/event.dart';
 import 'package:onetj/models/base_model.dart';
@@ -10,7 +11,7 @@ class AppUpdateMigrationViewModel extends BaseViewModel<UiEvent> {
   AppUpdateMigrationViewModel({
     ExternalLauncherService? externalLauncherService,
   }) : _externalLauncherService =
-            externalLauncherService ?? ExternalLauncherService.getInstance();
+            externalLauncherService ?? appLocator<ExternalLauncherService>();
 
   final ExternalLauncherService _externalLauncherService;
 

--- a/lib/features/dashboard/models/dashboard_model.dart
+++ b/lib/features/dashboard/models/dashboard_model.dart
@@ -1,5 +1,6 @@
 import 'package:onetj/services/tongji.dart';
 
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/repo/student_info_repository.dart';
 import 'package:onetj/repo/school_calendar_repository.dart';
 import 'package:onetj/repo/course_schedule_repository.dart';
@@ -31,7 +32,7 @@ class DashboardModel {
   }
 
   Future<StudentInfoData> getStudentInfo() async {
-    final StudentInfoRepository repo = StudentInfoRepository.getInstance();
+    final StudentInfoRepository repo = appLocator<StudentInfoRepository>();
     await repo.warmUp();
     return repo.getOrFetch(
       now: DateTime.now(),
@@ -51,7 +52,7 @@ class DashboardModel {
   Future<CourseScheduleData> getCourseSchedule() async {
     final DateTime now = DateTime.now();
     final CourseScheduleRepository repo =
-        CourseScheduleRepository.getInstance();
+        appLocator<CourseScheduleRepository>();
     await repo.warmUp();
     final String? termKey = await _termKeyResolver.resolveCurrentTermKey(
       now: now,

--- a/lib/features/dashboard/view_models/dashboard_view_model.dart
+++ b/lib/features/dashboard/view_models/dashboard_view_model.dart
@@ -26,7 +26,7 @@ class DashboardViewModel extends BaseViewModel<UiEvent> {
     AppUpdateService? appUpdateService,
   })  : _model = model ?? DashboardModel(),
         _settingsRepository =
-            settingsRepository ?? SettingsRepository.getInstance(),
+            settingsRepository ?? appLocator<SettingsRepository>(),
         _userCollectionService =
             userCollectionService ?? UserCollectionService(),
         _appUpdateService = appUpdateService ?? appLocator<AppUpdateService>() {
@@ -202,7 +202,7 @@ class DashboardViewModel extends BaseViewModel<UiEvent> {
 
   Future<void> _uploadUserCollectionWhenStudentInfoLoaded() async {
     try {
-      final StudentInfoRepository repo = StudentInfoRepository.getInstance();
+      final StudentInfoRepository repo = appLocator<StudentInfoRepository>();
       final StudentInfoData studentInfo = await repo.getOrFetch(
         now: DateTime.now(),
         fetcher: _model.fetchStudentInfo,
@@ -225,7 +225,7 @@ class DashboardViewModel extends BaseViewModel<UiEvent> {
 
   Future<void> loadSchoolCalendar() async {
     final SchoolCalendarRepository repo =
-        SchoolCalendarRepository.getInstance();
+        appLocator<SchoolCalendarRepository>();
     try {
       final DateTime now = DateTime.now();
       await repo.warmUp();

--- a/lib/features/grades/models/grades_model.dart
+++ b/lib/features/grades/models/grades_model.dart
@@ -1,3 +1,4 @@
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/services/tongji.dart';
 import 'package:onetj/repo/undergraduate_score_repository.dart';
 
@@ -12,7 +13,7 @@ class GradesModel {
 
   Future<UndergraduateScoreData> getUndergraduateScore() async {
     final UndergraduateScoreRepository repo =
-        UndergraduateScoreRepository.getInstance();
+        appLocator<UndergraduateScoreRepository>();
     return repo.getOrFetch(
       now: DateTime.now(),
       fetcher: () => fetchUndergraduateScore(calendarId: -1),
@@ -22,13 +23,13 @@ class GradesModel {
 
   Future<void> warmUpCache() async {
     final UndergraduateScoreRepository repo =
-        UndergraduateScoreRepository.getInstance();
+        appLocator<UndergraduateScoreRepository>();
     await repo.warmUp();
   }
 
   Future<UndergraduateScoreData> refreshUndergraduateScore() async {
     final UndergraduateScoreRepository repo =
-        UndergraduateScoreRepository.getInstance();
+        appLocator<UndergraduateScoreRepository>();
     return repo.refresh(
       now: DateTime.now(),
       fetcher: () => fetchUndergraduateScore(calendarId: -1),

--- a/lib/features/home/view_models/home_view_model.dart
+++ b/lib/features/home/view_models/home_view_model.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/models/base_model.dart';
 import 'package:onetj/features/home/models/home_model.dart';
 import 'package:onetj/models/timetable_index.dart';
@@ -48,7 +49,7 @@ class HomeViewModel extends BaseViewModel<Never> {
 
   Future<void> loadSchoolCalendar() async {
     final SchoolCalendarRepository repo =
-        SchoolCalendarRepository.getInstance();
+        appLocator<SchoolCalendarRepository>();
     try {
       await repo.warmUp();
       final SchoolCalendarData data = await repo.getOrFetch(
@@ -64,7 +65,7 @@ class HomeViewModel extends BaseViewModel<Never> {
   Future<void> loadCourseSchedule() async {
     try {
       final CourseScheduleRepository repo =
-          CourseScheduleRepository.getInstance();
+          appLocator<CourseScheduleRepository>();
       final CourseScheduleData data = await repo.getOrFetch(
         now: DateTime.now(),
         fetcher: _model.fetchCourseSchedule,

--- a/lib/features/launcher/view_models/launcher_view_model.dart
+++ b/lib/features/launcher/view_models/launcher_view_model.dart
@@ -60,7 +60,7 @@ class LauncherViewModel extends BaseViewModel<UiEvent> {
     final Future<void> webViewInitFuture =
         WebViewEnvironmentService.instance.initialize();
     final Future<SettingsData> settingsFuture =
-        SettingsRepository.getInstance().getSettings(
+        appLocator<SettingsRepository>().getSettings(
       refreshFromStorage: true,
     );
 
@@ -112,7 +112,7 @@ class LauncherViewModel extends BaseViewModel<UiEvent> {
   ///
   /// 如果 token 有效，则返回 [RoutePaths.home]，否则返回 [RoutePaths.login]。
   Future<String> _resolveInitialRoute() async {
-    final TokenRepository repo = TokenRepository.getInstance();
+    final TokenRepository repo = appLocator<TokenRepository>();
     final TokenData? token = await repo.getToken(refreshFromStorage: true);
 
     if (token != null &&

--- a/lib/features/settings/models/developer_settings_model.dart
+++ b/lib/features/settings/models/developer_settings_model.dart
@@ -1,3 +1,4 @@
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/features/settings/models/developer_settings_exception.dart';
 import 'package:onetj/repo/student_info_repository.dart';
 import 'package:onetj/services/tongji.dart';
@@ -9,7 +10,7 @@ class DeveloperSettingsModel {
     TongjiApi? tongjiApi,
     UserCollectionService? userCollectionService,
   })  : _studentInfoRepository =
-            studentInfoRepository ?? StudentInfoRepository.getInstance(),
+            studentInfoRepository ?? appLocator<StudentInfoRepository>(),
         _tongjiApi = tongjiApi ?? TongjiApi(),
         _userCollectionService =
             userCollectionService ?? UserCollectionService();

--- a/lib/features/settings/view_models/color_picker_view_model.dart
+++ b/lib/features/settings/view_models/color_picker_view_model.dart
@@ -49,7 +49,7 @@ class ColorPickerViewModel extends ChangeNotifier {
   })  : _themeChangeNotifier =
             themeChangeNotifier ?? appLocator<ThemeChangeNotifier>(),
         _presetRepository =
-            presetRepository ?? ColorPresetRepository.getInstance() {
+            presetRepository ?? appLocator<ColorPresetRepository>() {
     _snapshot = _themeChangeNotifier.preferences;
     _current = _snapshot;
     _presetName = '';

--- a/lib/features/settings/view_models/settings_view_model.dart
+++ b/lib/features/settings/view_models/settings_view_model.dart
@@ -41,7 +41,7 @@ class SettingsViewModel extends BaseViewModel<UiEvent> {
     SettingsRepository? settingsRepository,
     ThemeChangeNotifier? themeChangeNotifier,
   })  : _settingsRepository =
-            settingsRepository ?? SettingsRepository.getInstance(),
+            settingsRepository ?? appLocator<SettingsRepository>(),
         _themeChangeNotifier =
             themeChangeNotifier ?? appLocator<ThemeChangeNotifier>(),
         _hiveStorageService = HiveStorageService(),
@@ -257,10 +257,10 @@ class SettingsViewModel extends BaseViewModel<UiEvent> {
     errorMessage = null;
     notifyListeners();
     try {
-      await TokenRepository.getInstance().clearToken();
-      await StudentInfoRepository.getInstance().clearCache();
-      await SchoolCalendarRepository.getInstance().clearCache();
-      await CourseScheduleRepository.getInstance().clearCache();
+      await appLocator<TokenRepository>().clearToken();
+      await appLocator<StudentInfoRepository>().clearCache();
+      await appLocator<SchoolCalendarRepository>().clearCache();
+      await appLocator<CourseScheduleRepository>().clearCache();
       await CookieManager.instance(webViewEnvironment: _webViewEnvironment)
           .deleteAllCookies();
       AppLogger.logNavigation(

--- a/lib/features/timetable/models/timetable_model.dart
+++ b/lib/features/timetable/models/timetable_model.dart
@@ -1,5 +1,6 @@
 import 'package:onetj/services/tongji.dart';
 
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/repo/course_schedule_repository.dart';
 import 'package:onetj/repo/school_calendar_repository.dart';
 import 'package:onetj/services/timetable_index_builder.dart';
@@ -16,15 +17,15 @@ class TimetableModel {
   })  : _api = api ?? TongjiApi(),
         _indexBuilder = indexBuilder ?? const TimetableIndexBuilder(),
         _scheduleRepository =
-            scheduleRepository ?? CourseScheduleRepository.getInstance(),
+            scheduleRepository ?? appLocator<CourseScheduleRepository>(),
         _calendarRepository =
-            calendarRepository ?? SchoolCalendarRepository.getInstance(),
+            calendarRepository ?? appLocator<SchoolCalendarRepository>(),
         _termKeyResolver = termKeyResolver ??
             TermKeyResolver(
               calendarRepository:
-                  calendarRepository ?? SchoolCalendarRepository.getInstance(),
+                  calendarRepository ?? appLocator<SchoolCalendarRepository>(),
               scheduleRepository:
-                  scheduleRepository ?? CourseScheduleRepository.getInstance(),
+                  scheduleRepository ?? appLocator<CourseScheduleRepository>(),
             );
 
   final TongjiApi _api;

--- a/lib/features/timetable/view_models/timetable_view_model.dart
+++ b/lib/features/timetable/view_models/timetable_view_model.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/app/exception/app_exception.dart';
 import 'package:onetj/features/timetable/models/event.dart';
 import 'package:onetj/features/timetable/models/timetable_model.dart';
@@ -22,7 +23,7 @@ class TimetableViewModel extends BaseViewModel<UiEvent> {
     SettingsRepository? settingsRepository,
   })  : _model = model ?? TimetableModel(),
         _settingsRepository =
-            settingsRepository ?? SettingsRepository.getInstance(),
+            settingsRepository ?? appLocator<SettingsRepository>(),
         _maxWeek = maxWeek {
     _settingsSub = _settingsRepository.stream.listen(_handleSettingsChanged);
   }

--- a/lib/repo/app_update_state_repository.dart
+++ b/lib/repo/app_update_state_repository.dart
@@ -87,15 +87,10 @@ class AppUpdateStateData {
 }
 
 class AppUpdateStateRepository {
-  AppUpdateStateRepository._({required HiveInterface hive}) : _hive = hive;
+  AppUpdateStateRepository({HiveInterface? hive}) : _hive = hive ?? Hive;
 
   static const String _boxName = 'app_update_state';
   static const String _key = 'payload';
-  static AppUpdateStateRepository? _instance;
-
-  static AppUpdateStateRepository getInstance() {
-    return _instance ??= AppUpdateStateRepository._(hive: Hive);
-  }
 
   final HiveInterface _hive;
   AppUpdateStateData? _cached;

--- a/lib/repo/color_preset_repository.dart
+++ b/lib/repo/color_preset_repository.dart
@@ -91,27 +91,11 @@ class InMemoryColorPresetStorage implements ColorPresetStorage {
 
 /// 用户自定义预设仓库
 class ColorPresetRepository {
-  ColorPresetRepository._({
-    required ColorPresetStorage storage,
-  }) : _storage = storage;
-
-  static ColorPresetRepository? _instance;
+  ColorPresetRepository({
+    ColorPresetStorage? storage,
+  }) : _storage = storage ?? HiveColorPresetStorage();
 
   final ColorPresetStorage _storage;
-
-  static ColorPresetRepository getInstance() {
-    if (_instance != null) {
-      return _instance!;
-    }
-    _instance = ColorPresetRepository._(storage: HiveColorPresetStorage());
-    return _instance!;
-  }
-
-  static void resetForTesting({ColorPresetStorage? storage}) {
-    _instance = ColorPresetRepository._(
-      storage: storage ?? InMemoryColorPresetStorage(),
-    );
-  }
 
   Future<List<ThemePreferences>> getPresets() async {
     return _storage.read();

--- a/lib/repo/course_schedule_repository.dart
+++ b/lib/repo/course_schedule_repository.dart
@@ -473,29 +473,9 @@ class InMemoryCourseScheduleStorage implements CourseScheduleStorage {
 
 class CourseScheduleRepository extends BaseNetCachedRepository<
     CourseScheduleData, CourseScheduleCacheMeta, CourseScheduleStorage> {
-  CourseScheduleRepository._({
-    required CourseScheduleStorage storage,
-  }) : super(storage);
-
-  static CourseScheduleRepository? _instance;
-
-  static CourseScheduleRepository getInstance({
+  CourseScheduleRepository({
     CourseScheduleStorage? storage,
-  }) {
-    if (_instance != null) {
-      return _instance!;
-    }
-    final CourseScheduleRepository repo = CourseScheduleRepository._(
-      storage: storage ?? HiveCourseScheduleStorage(),
-    );
-    _instance = repo;
-    return repo;
-  }
-
-  @visibleForTesting
-  static void resetInstanceForTest() {
-    _instance = null;
-  }
+  }) : super(storage ?? HiveCourseScheduleStorage());
 
   String? _pendingTermKey;
 

--- a/lib/repo/school_calendar_repository.dart
+++ b/lib/repo/school_calendar_repository.dart
@@ -238,30 +238,11 @@ class InMemorySchoolCalendarStorage implements SchoolCalendarStorage {
 
 class SchoolCalendarRepository extends BaseNetCachedRepository<
     SchoolCalendarData, SchoolCalendarCacheMeta, SchoolCalendarStorage> {
-  SchoolCalendarRepository._({
-    required SchoolCalendarStorage storage,
-  }) : super(storage);
-
-  static SchoolCalendarRepository? _instance;
-  int? _fetchedWeekBeginDay;
-
-  static SchoolCalendarRepository getInstance({
+  SchoolCalendarRepository({
     SchoolCalendarStorage? storage,
-  }) {
-    if (_instance != null) {
-      return _instance!;
-    }
-    final SchoolCalendarRepository repo = SchoolCalendarRepository._(
-      storage: storage ?? HiveSchoolCalendarStorage(),
-    );
-    _instance = repo;
-    return repo;
-  }
+  }) : super(storage ?? HiveSchoolCalendarStorage());
 
-  @visibleForTesting
-  static void resetInstanceForTest() {
-    _instance = null;
-  }
+  int? _fetchedWeekBeginDay;
 
   @override
   SchoolCalendarCacheMeta buildMeta(DateTime now) {

--- a/lib/repo/settings_repository.dart
+++ b/lib/repo/settings_repository.dart
@@ -284,11 +284,10 @@ class InMemorySettingsStorage implements SettingsStorage {
 }
 
 class SettingsRepository {
-  SettingsRepository._({required SettingsStorage storage})
-      : _storage = storage,
+  SettingsRepository({SettingsStorage? storage})
+      : _storage = storage ?? HiveSettingsStorage(),
         _controller = StreamController<SettingsData>.broadcast();
 
-  static SettingsRepository? _instance;
   static final SettingsData _defaultSettings = SettingsData(
     maxWeek: kDefaultMaxWeek,
     timeSlotRanges: kDefaultTimeSlotRanges,
@@ -297,23 +296,6 @@ class SettingsRepository {
     userCollectionFields: kDefaultUserCollectionFields,
     selectedLaunchWallpaperRef: LaunchWallpaperRef.defaultValue,
   );
-
-  static SettingsRepository getInstance() {
-    if (_instance != null) {
-      return _instance!;
-    }
-    final SettingsRepository repo = SettingsRepository._(
-      storage: HiveSettingsStorage(),
-    );
-    _instance = repo;
-    return repo;
-  }
-
-  static void resetForTesting({SettingsStorage? storage}) {
-    _instance = SettingsRepository._(
-      storage: storage ?? InMemorySettingsStorage(),
-    );
-  }
 
   final SettingsStorage _storage;
   final StreamController<SettingsData> _controller;

--- a/lib/repo/student_info_repository.dart
+++ b/lib/repo/student_info_repository.dart
@@ -360,29 +360,9 @@ class InMemoryStudentInfoStorage implements StudentInfoStorage {
 
 class StudentInfoRepository extends BaseNetCachedRepository<StudentInfoData,
     StudentInfoCacheMeta, StudentInfoStorage> {
-  StudentInfoRepository._({
-    required StudentInfoStorage storage,
-  }) : super(storage);
-
-  static StudentInfoRepository? _instance;
-
-  static StudentInfoRepository getInstance({
+  StudentInfoRepository({
     StudentInfoStorage? storage,
-  }) {
-    if (_instance != null) {
-      return _instance!;
-    }
-    final StudentInfoRepository repo = StudentInfoRepository._(
-      storage: storage ?? HiveStudentInfoStorage(),
-    );
-    _instance = repo;
-    return repo;
-  }
-
-  @visibleForTesting
-  static void resetInstanceForTest() {
-    _instance = null;
-  }
+  }) : super(storage ?? HiveStudentInfoStorage());
 
   String? _pendingVersionKey;
 

--- a/lib/repo/template_repository.dart
+++ b/lib/repo/template_repository.dart
@@ -106,29 +106,9 @@ class HiveTemplateStorage implements TemplateStorage {
 
 class TemplateRepository extends BaseNetCachedRepository<TemplateData,
     TemplateCacheMeta, TemplateStorage> {
-  TemplateRepository._({
-    required TemplateStorage storage,
-  }) : super(storage);
-
-  static TemplateRepository? _instance;
-
-  static TemplateRepository getInstance({
+  TemplateRepository({
     TemplateStorage? storage,
-  }) {
-    if (_instance != null) {
-      return _instance!;
-    }
-    final TemplateRepository repo = TemplateRepository._(
-      storage: storage ?? HiveTemplateStorage(),
-    );
-    _instance = repo;
-    return repo;
-  }
-
-  @visibleForTesting
-  static void resetInstanceForTest() {
-    _instance = null;
-  }
+  }) : super(storage ?? HiveTemplateStorage());
 
   @override
   TemplateCacheMeta buildMeta(DateTime now) {

--- a/lib/repo/theme_repository.dart
+++ b/lib/repo/theme_repository.dart
@@ -85,13 +85,11 @@ class InMemoryThemeStorage implements ThemeStorage {
 ///
 /// 继承 [ChangeNotifier]，当主题偏好变更时通知监听者。
 class ThemeRepository extends ChangeNotifier {
-  ThemeRepository._({
-    required ThemeStorage storage,
-  }) : _storage = storage {
+  ThemeRepository({
+    ThemeStorage? storage,
+  }) : _storage = storage ?? HiveThemeStorage() {
     _preferences = ThemePreferences.defaultPreferences;
   }
-
-  static ThemeRepository? _instance;
 
   final ThemeStorage _storage;
   late ThemePreferences _preferences;
@@ -102,22 +100,6 @@ class ThemeRepository extends ChangeNotifier {
 
   /// 是否已从存储中加载完成
   bool get initialized => _initialized;
-
-  /// 获取单例
-  static ThemeRepository getInstance() {
-    if (_instance != null) {
-      return _instance!;
-    }
-    _instance = ThemeRepository._(storage: HiveThemeStorage());
-    return _instance!;
-  }
-
-  /// 重置单例（用于测试）
-  static void resetForTesting({ThemeStorage? storage}) {
-    _instance = ThemeRepository._(
-      storage: storage ?? InMemoryThemeStorage(),
-    );
-  }
 
   /// 从 Hive 加载主题偏好
   ///

--- a/lib/repo/token_repository.dart
+++ b/lib/repo/token_repository.dart
@@ -146,22 +146,10 @@ class InMemoryTokenStorage implements TokenStorage {
 
 /// 用于存储和管理认证令牌的仓库类。
 ///
-/// 使用 getInstance 方法获取单例实例。
+/// 通过 `appLocator<TokenRepository>()` 获取实例。
 class TokenRepository {
-  TokenRepository._({required TokenStorage storage}) : _storage = storage;
-
-  static TokenRepository? _instance;
-
-  static TokenRepository getInstance() {
-    if (_instance != null) {
-      return _instance!;
-    }
-    final TokenRepository repo = TokenRepository._(
-      storage: HiveTokenStorage(),
-    );
-    _instance = repo;
-    return repo;
-  }
+  TokenRepository({TokenStorage? storage})
+      : _storage = storage ?? HiveTokenStorage();
 
   final TokenStorage _storage;
   TokenData? _cached;

--- a/lib/repo/undergraduate_score_repository.dart
+++ b/lib/repo/undergraduate_score_repository.dart
@@ -447,28 +447,8 @@ class UndergraduateScoreRepository extends BaseNetCachedRepository<
     UndergraduateScoreData,
     UndergraduateScoreCacheMeta,
     UndergraduateScoreStorage> {
-  UndergraduateScoreRepository._({required UndergraduateScoreStorage storage})
-      : super(storage);
-
-  static UndergraduateScoreRepository? _instance;
-
-  static UndergraduateScoreRepository getInstance({
-    UndergraduateScoreStorage? storage,
-  }) {
-    if (_instance != null) {
-      return _instance!;
-    }
-    final UndergraduateScoreRepository repo = UndergraduateScoreRepository._(
-      storage: storage ?? HiveUndergraduateScoreStorage(),
-    );
-    _instance = repo;
-    return repo;
-  }
-
-  @visibleForTesting
-  static void resetInstanceForTest() {
-    _instance = null;
-  }
+  UndergraduateScoreRepository({UndergraduateScoreStorage? storage})
+      : super(storage ?? HiveUndergraduateScoreStorage());
 
   String? _pendingVersionKey;
 

--- a/lib/services/app_update_api.dart
+++ b/lib/services/app_update_api.dart
@@ -10,12 +10,6 @@ import 'package:onetj/models/app_update_info.dart';
 class AppUpdateApi {
   AppUpdateApi();
 
-  static AppUpdateApi? _instance;
-
-  static AppUpdateApi getInstance() {
-    return _instance ??= AppUpdateApi();
-  }
-
   Future<AppUpdateCheckResult> checkLatest({
     required String platform,
     String? arch,

--- a/lib/services/app_update_service.dart
+++ b/lib/services/app_update_service.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 import 'package:onetj/app/constant/app_version_constant.dart';
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/app/exception/app_exception.dart';
 import 'package:onetj/app/logging/logger.dart';
 import 'package:onetj/models/app_update_info.dart';
@@ -28,13 +29,8 @@ class AppUpdateService {
   AppUpdateService({
     AppUpdateApi? api,
     AppUpdateStateRepository? repository,
-  })  : _api = api ?? AppUpdateApi(),
-        _repository = repository ?? AppUpdateStateRepository.getInstance();
-
-  static AppUpdateService? _instance;
-  static AppUpdateService getInstance() {
-    return _instance ??= AppUpdateService();
-  }
+  })  : _api = api ?? appLocator<AppUpdateApi>(),
+        _repository = repository ?? appLocator<AppUpdateStateRepository>();
 
   final AppUpdateApi _api;
   final AppUpdateStateRepository _repository;

--- a/lib/services/external_launcher_service.dart
+++ b/lib/services/external_launcher_service.dart
@@ -8,12 +8,6 @@ enum ExternalUrlLaunchResult {
 class ExternalLauncherService {
   ExternalLauncherService();
 
-  static ExternalLauncherService? _instance;
-
-  static ExternalLauncherService getInstance() {
-    return _instance ??= ExternalLauncherService();
-  }
-
   Uri? tryParseExternalUrl(String url) {
     final String trimmed = url.trim();
     if (trimmed.isEmpty) {

--- a/lib/services/term_key_resolver.dart
+++ b/lib/services/term_key_resolver.dart
@@ -1,3 +1,4 @@
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/repo/course_schedule_repository.dart';
 import 'package:onetj/repo/school_calendar_repository.dart';
 
@@ -6,9 +7,9 @@ class TermKeyResolver {
     SchoolCalendarRepository? calendarRepository,
     CourseScheduleRepository? scheduleRepository,
   })  : _calendarRepository =
-            calendarRepository ?? SchoolCalendarRepository.getInstance(),
+            calendarRepository ?? appLocator<SchoolCalendarRepository>(),
         _scheduleRepository =
-            scheduleRepository ?? CourseScheduleRepository.getInstance();
+            scheduleRepository ?? appLocator<CourseScheduleRepository>();
 
   final SchoolCalendarRepository _calendarRepository;
   final CourseScheduleRepository _scheduleRepository;

--- a/lib/services/tongji.dart
+++ b/lib/services/tongji.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import 'package:onetj/app/constant/site_constant.dart';
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/app/exception/app_exception.dart';
 import 'package:onetj/app/logging/logger.dart';
 import 'package:onetj/models/api_response.dart';
@@ -50,7 +51,7 @@ class TongjiApi {
     if (response.statusCode >= 200 && response.statusCode < 300) {
       final Code2TokenData data =
           Code2TokenData.fromJson(json.decode(response.body));
-      final TokenRepository repo = TokenRepository.getInstance();
+      final TokenRepository repo = appLocator<TokenRepository>();
       await repo.saveFromCode2Token(data);
       return;
     }
@@ -210,7 +211,7 @@ class TongjiApi {
   }
 
   Future<String> _getValidAccessToken() async {
-    final TokenRepository repo = TokenRepository.getInstance();
+    final TokenRepository repo = appLocator<TokenRepository>();
     final TokenData? token = await repo.getToken(refreshFromStorage: true);
     if (token == null) {
       throw AppException('AUTH_REQUIRED', 'Missing access token');

--- a/test/app/theme/theme_change_notifier_test.dart
+++ b/test/app/theme/theme_change_notifier_test.dart
@@ -11,8 +11,7 @@ void main() {
 
   setUp(() {
     storage = InMemoryThemeStorage();
-    ThemeRepository.resetForTesting(storage: storage);
-    repo = ThemeRepository.getInstance();
+    repo = ThemeRepository(storage: storage);
     notifier = ThemeChangeNotifier(repository: repo);
   });
 

--- a/test/features/app_update/app_update_migration_view_model_test.dart
+++ b/test/features/app_update/app_update_migration_view_model_test.dart
@@ -78,7 +78,7 @@ void main() {
         return null;
       });
       final AppUpdateMigrationViewModel viewModel =
-          AppUpdateMigrationViewModel();
+          AppUpdateMigrationViewModel(externalLauncherService: ExternalLauncherService());
 
       final Future<UiEvent> nextEvent = viewModel.events.first;
       await viewModel.copyLink('https://example.com/update.apk');
@@ -98,7 +98,7 @@ void main() {
         return null;
       });
       final AppUpdateMigrationViewModel viewModel =
-          AppUpdateMigrationViewModel();
+          AppUpdateMigrationViewModel(externalLauncherService: ExternalLauncherService());
 
       final Future<UiEvent> nextEvent = viewModel.events.first;
       await viewModel.copyLink('https://example.com/update.apk');

--- a/test/features/dashboard/dashboard_view_model_test.dart
+++ b/test/features/dashboard/dashboard_view_model_test.dart
@@ -1,12 +1,27 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:onetj/app/di/dependencies.dart';
 import 'package:onetj/features/dashboard/view_models/dashboard_view_model.dart';
 import 'package:onetj/models/event_model.dart';
+import 'package:onetj/repo/course_schedule_repository.dart';
+import 'package:onetj/repo/school_calendar_repository.dart';
 import 'package:onetj/repo/settings_repository.dart';
 import 'package:onetj/services/app_update_service.dart';
 
 void main() {
   setUp(() {
-    SettingsRepository.resetForTesting();
+    appLocator.registerSingleton<SettingsRepository>(
+      SettingsRepository(storage: InMemorySettingsStorage()),
+    );
+    appLocator.registerSingleton<SchoolCalendarRepository>(
+      SchoolCalendarRepository(storage: InMemorySchoolCalendarStorage()),
+    );
+    appLocator.registerSingleton<CourseScheduleRepository>(
+      CourseScheduleRepository(storage: InMemoryCourseScheduleStorage()),
+    );
+  });
+
+  tearDown(() async {
+    await resetDependencies();
   });
 
   group('DashboardViewModel.skipUpdateVersion', () {

--- a/test/features/home/views/widgets/home_shell_back_button_test.dart
+++ b/test/features/home/views/widgets/home_shell_back_button_test.dart
@@ -13,8 +13,8 @@ void main() {
   late ThemeChangeNotifier themeChangeNotifier;
 
   setUp(() async {
-    ThemeRepository.resetForTesting(storage: InMemoryThemeStorage());
-    final ThemeRepository repository = ThemeRepository.getInstance();
+    final ThemeRepository repository =
+        ThemeRepository(storage: InMemoryThemeStorage());
     await repository.initialize();
     themeChangeNotifier = ThemeChangeNotifier(repository: repository);
   });

--- a/test/features/settings/view_models/color_picker_view_model_test.dart
+++ b/test/features/settings/view_models/color_picker_view_model_test.dart
@@ -18,15 +18,13 @@ Future<void> _waitForLoad(ColorPickerViewModel vm) => _pumpEventQueue();
 
 /// 测试用的 ThemeChangeNotifier，使用 InMemoryThemeStorage 隔离
 ThemeChangeNotifier _createFakeThemeNotifier() {
-  ThemeRepository.resetForTesting();
-  final repo = ThemeRepository.getInstance();
+  final repo = ThemeRepository(storage: InMemoryThemeStorage());
   return ThemeChangeNotifier(repository: repo);
 }
 
 /// 测试用的 ColorPresetRepository，使用 InMemoryColorPresetStorage 隔离
 ColorPresetRepository _createFakePresetRepo() {
-  ColorPresetRepository.resetForTesting();
-  return ColorPresetRepository.getInstance();
+  return ColorPresetRepository(storage: InMemoryColorPresetStorage());
 }
 
 void main() {

--- a/test/repo/color_preset_repository_test.dart
+++ b/test/repo/color_preset_repository_test.dart
@@ -9,8 +9,7 @@ void main() {
 
   setUp(() {
     storage = InMemoryColorPresetStorage();
-    ColorPresetRepository.resetForTesting(storage: storage);
-    repo = ColorPresetRepository.getInstance();
+    repo = ColorPresetRepository(storage: storage);
   });
 
   const presetA = ThemePreferences(

--- a/test/repo/course_schedule_repository_test.dart
+++ b/test/repo/course_schedule_repository_test.dart
@@ -8,9 +8,8 @@ void main() {
     late CourseScheduleRepository repo;
 
     setUp(() {
-      CourseScheduleRepository.resetInstanceForTest();
       storage = InMemoryCourseScheduleStorage();
-      repo = CourseScheduleRepository.getInstance(storage: storage);
+      repo = CourseScheduleRepository(storage: storage);
     });
 
     test('fetches and caches data on first getOrFetch', () async {

--- a/test/repo/student_info_repository_test.dart
+++ b/test/repo/student_info_repository_test.dart
@@ -56,9 +56,8 @@ void main() {
     late StudentInfoRepository repo;
 
     setUp(() {
-      StudentInfoRepository.resetInstanceForTest();
       storage = InMemoryStudentInfoStorage();
-      repo = StudentInfoRepository.getInstance(storage: storage);
+      repo = StudentInfoRepository(storage: storage);
     });
 
     test('fetches and caches data on first getOrFetch', () async {

--- a/test/repo/theme_repository_test.dart
+++ b/test/repo/theme_repository_test.dart
@@ -10,8 +10,7 @@ void main() {
 
   setUp(() {
     storage = InMemoryThemeStorage();
-    ThemeRepository.resetForTesting(storage: storage);
-    repo = ThemeRepository.getInstance();
+    repo = ThemeRepository(storage: storage);
   });
 
   group('ThemeRepository', () {

--- a/test/repo/undergraduate_score_repository_test.dart
+++ b/test/repo/undergraduate_score_repository_test.dart
@@ -41,9 +41,8 @@ void main() {
     late UndergraduateScoreRepository repo;
 
     setUp(() {
-      UndergraduateScoreRepository.resetInstanceForTest();
       storage = InMemoryUndergraduateScoreStorage();
-      repo = UndergraduateScoreRepository.getInstance(storage: storage);
+      repo = UndergraduateScoreRepository(storage: storage);
     });
 
     test('fetches and caches data on first getOrFetch', () async {

--- a/test/services/app_update_service_test.dart
+++ b/test/services/app_update_service_test.dart
@@ -7,6 +7,7 @@ import 'package:hive/hive.dart';
 import 'package:onetj/app/exception/app_exception.dart';
 import 'package:onetj/models/app_update_info.dart';
 import 'package:onetj/repo/app_update_state_repository.dart';
+import 'package:onetj/services/app_update_api.dart';
 import 'package:onetj/services/app_update_service.dart';
 import 'package:path/path.dart' as p;
 import 'package:flutter/services.dart';
@@ -19,6 +20,7 @@ void main() {
   late Directory tempDir;
   late HttpServer server;
   late AppUpdateService service;
+  late AppUpdateStateRepository repository;
 
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('app_update_service_test_');
@@ -34,8 +36,10 @@ void main() {
       }
       return null;
     });
+    repository = AppUpdateStateRepository();
     service = AppUpdateService(
-      repository: AppUpdateStateRepository.getInstance(),
+      api: AppUpdateApi(),
+      repository: repository,
     );
     server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
   });
@@ -78,8 +82,7 @@ void main() {
       expect(await file.readAsBytes(), payload);
       expect(p.basename(file.path), 'onetj_installer.exe');
 
-      final AppUpdateStateData state =
-          await AppUpdateStateRepository.getInstance().getState(
+      final AppUpdateStateData state = await repository.getState(
         refreshFromStorage: true,
       );
       expect(state.pendingFilePath, file.path);


### PR DESCRIPTION
## 概述

消除「GetIt 容器 + 静态 getInstance 单例」双轨制，所有 repo/service 统一注册进 `appLocator`，消费方统一从容器解析依赖。

## 改动内容

- **repo/service 构造函数公开化**：12 个使用 `getInstance()` 静态单例的类（10 个 repository + `AppUpdateApi`/`AppUpdateService`/`ExternalLauncherService`）改为公开构造函数，默认 storage/hive 实现下沉为参数默认值，删除 `_instance`/`getInstance()`/`resetForTesting()`/`resetInstanceForTest()` 等静态成员
- **`dependencies.dart` 重写**：统一注册全部 14 个依赖为 lazy singleton，移除冗余的 `isRegistered` 样板
- **消费方迁移**：约 20 处 `getInstance()` 调用全部替换为 `appLocator<T>()`（构造函数默认参数或方法内局部获取）
- **测试适配**：repo 测试直接以 InMemoryStorage 构造实例；依赖容器解析的测试在 setUp 中注册 InMemory 实现、tearDown 重置容器

## 验证

- `flutter analyze`：lib/test 无 error/warning
- 全量测试 237 个全部通过