### PR TITLE
fix: 按请求上下文隔离缓存 single-flight

### DIFF
--- a/lib/repo/base_cached_repository.dart
+++ b/lib/repo/base_cached_repository.dart
@@ -33,6 +33,7 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
   TMeta? _cachedMeta;
   Future<void>? _pendingPersist;
   Future<TData>? _inFlightFetch;
+  Object? _inFlightRequestKey;
   Completer<void>? _clearCompleter;
   @protected
   TData? get cachedData => _cachedData;
@@ -45,7 +46,11 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
   Future<void> persistMeta(TMeta meta) async => await _storage.saveMeta(meta);
   Future<void> clearStorage() async => await _storage.clear();
 
-  TMeta buildMeta(DateTime now);
+  TMeta buildMeta(
+    DateTime now,
+    TData data, {
+    Object? requestKey,
+  });
 
   Future<void> warmUp() async {
     _throwIfClearing();
@@ -63,6 +68,7 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
     required Duration ttl,
     required TData? cached,
     required TMeta? meta,
+    Object? requestKey,
   }) {
     if (cached == null || meta == null) {
       return true;
@@ -81,6 +87,7 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
     required DateTime now,
     required Future<TData> Function() fetcher,
     Duration ttl = const Duration(days: 7),
+    Object? requestKey,
   }) async {
     _throwIfClearing();
     final TData? cached = _cachedData;
@@ -90,18 +97,28 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
       ttl: ttl,
       cached: cached,
       meta: meta,
+      requestKey: requestKey,
     );
     if (!shouldFetchFlag) {
       return cached!;
     }
-    return _runSingleFlightFetch(now: now, fetcher: fetcher);
+    return _runSingleFlightFetch(
+      now: now,
+      fetcher: fetcher,
+      requestKey: requestKey,
+    );
   }
 
   Future<TData> refresh({
     required DateTime now,
     required Future<TData> Function() fetcher,
+    Object? requestKey,
   }) {
-    return _runSingleFlightFetch(now: now, fetcher: fetcher);
+    return _runSingleFlightFetch(
+      now: now,
+      fetcher: fetcher,
+      requestKey: requestKey,
+    );
   }
 
   Future<void> flush() {
@@ -132,6 +149,7 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
       _cachedData = null;
       _cachedMeta = null;
       _inFlightFetch = null;
+      _inFlightRequestKey = null;
       await clearStorage();
       clearCompleter.complete();
     } catch (error, stackTrace) {
@@ -147,32 +165,65 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
   Future<TData> _runSingleFlightFetch({
     required DateTime now,
     required Future<TData> Function() fetcher,
+    required Object? requestKey,
   }) {
     _throwIfClearing();
     final Future<TData>? inFlight = _inFlightFetch;
     if (inFlight != null) {
-      return inFlight;
+      if (_inFlightRequestKey == requestKey) {
+        return inFlight;
+      }
+      return _runAfterInFlight(
+        inFlight: inFlight,
+        now: now,
+        fetcher: fetcher,
+        requestKey: requestKey,
+      );
     }
     late final Future<TData> nextInFlight;
     nextInFlight = () async {
       try {
-        return await _fetchAndSave(now: now, fetcher: fetcher);
+        return await _fetchAndSave(
+          now: now,
+          fetcher: fetcher,
+          requestKey: requestKey,
+        );
       } finally {
         if (identical(_inFlightFetch, nextInFlight)) {
           _inFlightFetch = null;
+          _inFlightRequestKey = null;
         }
       }
     }();
     _inFlightFetch = nextInFlight;
+    _inFlightRequestKey = requestKey;
     return nextInFlight;
+  }
+
+  Future<TData> _runAfterInFlight({
+    required Future<TData> inFlight,
+    required DateTime now,
+    required Future<TData> Function() fetcher,
+    required Object? requestKey,
+  }) async {
+    try {
+      await inFlight;
+    } catch (_) {}
+    _throwIfClearing();
+    return _runSingleFlightFetch(
+      now: now,
+      fetcher: fetcher,
+      requestKey: requestKey,
+    );
   }
 
   Future<TData> _fetchAndSave({
     required DateTime now,
     required Future<TData> Function() fetcher,
+    required Object? requestKey,
   }) async {
     final TData fetched = await fetcher();
-    final TMeta meta = buildMeta(now);
+    final TMeta meta = buildMeta(now, fetched, requestKey: requestKey);
     _saveCache(data: fetched, meta: meta, persist: true);
     return fetched;
   }

--- a/lib/repo/course_schedule_repository.dart
+++ b/lib/repo/course_schedule_repository.dart
@@ -122,13 +122,15 @@ class CourseScheduleRepository extends BaseNetCachedRepository<
     CourseScheduleStorage? storage,
   }) : super(storage ?? HiveCourseScheduleStorage());
 
-  String? _pendingTermKey;
-
   @override
-  CourseScheduleCacheMeta buildMeta(DateTime now) {
+  CourseScheduleCacheMeta buildMeta(
+    DateTime now,
+    CourseScheduleData data, {
+    Object? requestKey,
+  }) {
     return CourseScheduleCacheMeta(
       lastFetchedAtMillis: now.millisecondsSinceEpoch,
-      termKey: _pendingTermKey,
+      termKey: requestKey as String?,
     );
   }
 
@@ -151,36 +153,39 @@ class CourseScheduleRepository extends BaseNetCachedRepository<
   }
 
   @override
+  bool shouldFetch({
+    required DateTime now,
+    required Duration ttl,
+    required CourseScheduleData? cached,
+    required CourseScheduleCacheMeta? meta,
+    Object? requestKey,
+  }) {
+    if (meta == null || meta.termKey != requestKey) {
+      return true;
+    }
+    return super.shouldFetch(
+      now: now,
+      ttl: ttl,
+      cached: cached,
+      meta: meta,
+      requestKey: requestKey,
+    );
+  }
+
+  @override
   Future<CourseScheduleData> getOrFetch({
     required DateTime now,
     required Future<CourseScheduleData> Function() fetcher,
     String? termKey,
     Duration ttl = const Duration(days: 7),
-  }) async {
-    _pendingTermKey ??= termKey;
-    final CourseScheduleData data;
-    try {
-      data = await super.getOrFetch(
-        now: now,
-        fetcher: fetcher,
-        ttl: ttl,
-      );
-      return data;
-    } finally {
-      _pendingTermKey = null;
-    }
-  }
-
-  @override
-  bool shouldFetch(
-      {required DateTime now,
-      required Duration ttl,
-      required CourseScheduleData? cached,
-      required CourseScheduleCacheMeta? meta}) {
-    if (meta == null || meta.termKey != _pendingTermKey) {
-      return true;
-    }
-    return super.shouldFetch(now: now, ttl: ttl, cached: cached, meta: meta);
+    Object? requestKey,
+  }) {
+    return super.getOrFetch(
+      now: now,
+      fetcher: fetcher,
+      ttl: ttl,
+      requestKey: termKey ?? requestKey,
+    );
   }
 
   @override
@@ -188,17 +193,12 @@ class CourseScheduleRepository extends BaseNetCachedRepository<
     required DateTime now,
     required Future<CourseScheduleData> Function() fetcher,
     String? termKey,
-  }) async {
-    _pendingTermKey ??= termKey;
-    final CourseScheduleData data;
-    try {
-      data = await super.refresh(
-        now: now,
-        fetcher: fetcher,
-      );
-      return data;
-    } finally {
-      _pendingTermKey = null;
-    }
+    Object? requestKey,
+  }) {
+    return super.refresh(
+      now: now,
+      fetcher: fetcher,
+      requestKey: termKey ?? requestKey,
+    );
   }
 }

--- a/lib/repo/school_calendar_repository.dart
+++ b/lib/repo/school_calendar_repository.dart
@@ -121,15 +121,15 @@ class SchoolCalendarRepository extends BaseNetCachedRepository<
     SchoolCalendarStorage? storage,
   }) : super(storage ?? HiveSchoolCalendarStorage());
 
-  int? _fetchedWeekBeginDay;
-
   @override
-  SchoolCalendarCacheMeta buildMeta(DateTime now) {
-    final int weekBeginDay = _fetchedWeekBeginDay ?? 0;
-    _fetchedWeekBeginDay = null;
+  SchoolCalendarCacheMeta buildMeta(
+    DateTime now,
+    SchoolCalendarData data, {
+    Object? requestKey,
+  }) {
     return SchoolCalendarCacheMeta(
       lastFetchedAtMillis: now.millisecondsSinceEpoch,
-      weekBeginDay: weekBeginDay,
+      weekBeginDay: data.schoolCalendar.weekBeginDay,
     );
   }
 
@@ -139,12 +139,14 @@ class SchoolCalendarRepository extends BaseNetCachedRepository<
     required Duration ttl,
     required SchoolCalendarData? cached,
     required SchoolCalendarCacheMeta? meta,
+    Object? requestKey,
   }) {
     final bool baseShouldFetch = super.shouldFetch(
       now: now,
       ttl: ttl,
       cached: cached,
       meta: meta,
+      requestKey: requestKey,
     );
     if (baseShouldFetch || meta == null) {
       return baseShouldFetch;
@@ -176,32 +178,13 @@ class SchoolCalendarRepository extends BaseNetCachedRepository<
     required DateTime now,
     required Future<SchoolCalendarData> Function() fetcher,
     Duration ttl = const Duration(days: 1),
+    Object? requestKey,
   }) {
     return super.getOrFetch(
       now: now,
-      fetcher: _withWeekBeginDay(fetcher),
+      fetcher: fetcher,
       ttl: ttl,
+      requestKey: requestKey,
     );
-  }
-
-  @override
-  Future<SchoolCalendarData> refresh({
-    required DateTime now,
-    required Future<SchoolCalendarData> Function() fetcher,
-  }) {
-    return super.refresh(
-      now: now,
-      fetcher: _withWeekBeginDay(fetcher),
-    );
-  }
-
-  Future<SchoolCalendarData> Function() _withWeekBeginDay(
-    Future<SchoolCalendarData> Function() fetcher,
-  ) {
-    return () async {
-      final SchoolCalendarData data = await fetcher();
-      _fetchedWeekBeginDay = data.schoolCalendar.weekBeginDay;
-      return data;
-    };
   }
 }

--- a/lib/repo/student_info_repository.dart
+++ b/lib/repo/student_info_repository.dart
@@ -122,13 +122,15 @@ class StudentInfoRepository extends BaseNetCachedRepository<StudentInfoData,
     StudentInfoStorage? storage,
   }) : super(storage ?? HiveStudentInfoStorage());
 
-  String? _pendingVersionKey;
-
   @override
-  StudentInfoCacheMeta buildMeta(DateTime now) {
+  StudentInfoCacheMeta buildMeta(
+    DateTime now,
+    StudentInfoData data, {
+    Object? requestKey,
+  }) {
     return StudentInfoCacheMeta(
       lastFetchedAtMillis: now.millisecondsSinceEpoch,
-      versionKey: _pendingVersionKey,
+      versionKey: requestKey as String?,
     );
   }
 
@@ -138,23 +140,22 @@ class StudentInfoRepository extends BaseNetCachedRepository<StudentInfoData,
     required Duration ttl,
     required StudentInfoData? cached,
     required StudentInfoCacheMeta? meta,
+    Object? requestKey,
   }) {
     final bool shouldFetchByBase = super.shouldFetch(
       now: now,
       ttl: ttl,
       cached: cached,
       meta: meta,
+      requestKey: requestKey,
     );
     if (shouldFetchByBase) {
       return true;
     }
-    final String? versionKey = _pendingVersionKey;
-    if (versionKey != null &&
+    final String? versionKey = requestKey as String?;
+    return versionKey != null &&
         versionKey.isNotEmpty &&
-        meta?.versionKey != versionKey) {
-      return true;
-    }
-    return false;
+        meta?.versionKey != versionKey;
   }
 
   Future<StudentInfoData?> getCached({
@@ -181,18 +182,14 @@ class StudentInfoRepository extends BaseNetCachedRepository<StudentInfoData,
     required Future<StudentInfoData> Function() fetcher,
     String? versionKey,
     Duration ttl = const Duration(days: 7),
-  }) async {
-    _pendingVersionKey =
-        (versionKey != null && versionKey.isNotEmpty) ? versionKey : null;
-    try {
-      return await super.getOrFetch(
-        now: now,
-        fetcher: fetcher,
-        ttl: ttl,
-      );
-    } finally {
-      _pendingVersionKey = null;
-    }
+    Object? requestKey,
+  }) {
+    return super.getOrFetch(
+      now: now,
+      fetcher: fetcher,
+      ttl: ttl,
+      requestKey: _normalizeVersionKey(versionKey) ?? requestKey,
+    );
   }
 
   @override
@@ -200,13 +197,16 @@ class StudentInfoRepository extends BaseNetCachedRepository<StudentInfoData,
     required DateTime now,
     required Future<StudentInfoData> Function() fetcher,
     String? versionKey,
-  }) async {
-    _pendingVersionKey =
-        (versionKey != null && versionKey.isNotEmpty) ? versionKey : null;
-    try {
-      return await super.refresh(now: now, fetcher: fetcher);
-    } finally {
-      _pendingVersionKey = null;
-    }
+    Object? requestKey,
+  }) {
+    return super.refresh(
+      now: now,
+      fetcher: fetcher,
+      requestKey: _normalizeVersionKey(versionKey) ?? requestKey,
+    );
+  }
+
+  String? _normalizeVersionKey(String? versionKey) {
+    return versionKey != null && versionKey.isNotEmpty ? versionKey : null;
   }
 }

--- a/lib/repo/template_repository.dart
+++ b/lib/repo/template_repository.dart
@@ -90,7 +90,11 @@ class TemplateRepository extends BaseNetCachedRepository<TemplateData,
   }) : super(storage ?? HiveTemplateStorage());
 
   @override
-  TemplateCacheMeta buildMeta(DateTime now) {
+  TemplateCacheMeta buildMeta(
+    DateTime now,
+    TemplateData data, {
+    Object? requestKey,
+  }) {
     return TemplateCacheMeta(
       lastFetchedAtMillis: now.millisecondsSinceEpoch,
     );

--- a/lib/repo/undergraduate_score_repository.dart
+++ b/lib/repo/undergraduate_score_repository.dart
@@ -123,13 +123,15 @@ class UndergraduateScoreRepository extends BaseNetCachedRepository<
   UndergraduateScoreRepository({UndergraduateScoreStorage? storage})
       : super(storage ?? HiveUndergraduateScoreStorage());
 
-  String? _pendingVersionKey;
-
   @override
-  UndergraduateScoreCacheMeta buildMeta(DateTime now) {
+  UndergraduateScoreCacheMeta buildMeta(
+    DateTime now,
+    UndergraduateScoreData data, {
+    Object? requestKey,
+  }) {
     return UndergraduateScoreCacheMeta(
       lastFetchedAtMillis: now.millisecondsSinceEpoch,
-      versionKey: _pendingVersionKey,
+      versionKey: requestKey as String?,
     );
   }
 
@@ -139,23 +141,22 @@ class UndergraduateScoreRepository extends BaseNetCachedRepository<
     required Duration ttl,
     required UndergraduateScoreData? cached,
     required UndergraduateScoreCacheMeta? meta,
+    Object? requestKey,
   }) {
     final bool shouldFetchByBase = super.shouldFetch(
       now: now,
       ttl: ttl,
       cached: cached,
       meta: meta,
+      requestKey: requestKey,
     );
     if (shouldFetchByBase) {
       return true;
     }
-    final String? versionKey = _pendingVersionKey;
-    if (versionKey != null &&
+    final String? versionKey = requestKey as String?;
+    return versionKey != null &&
         versionKey.isNotEmpty &&
-        meta?.versionKey != versionKey) {
-      return true;
-    }
-    return false;
+        meta?.versionKey != versionKey;
   }
 
   Future<UndergraduateScoreData?> getCached({
@@ -182,18 +183,14 @@ class UndergraduateScoreRepository extends BaseNetCachedRepository<
     required Future<UndergraduateScoreData> Function() fetcher,
     String? versionKey,
     Duration ttl = const Duration(days: 7),
-  }) async {
-    _pendingVersionKey =
-        (versionKey != null && versionKey.isNotEmpty) ? versionKey : null;
-    try {
-      return await super.getOrFetch(
-        now: now,
-        fetcher: fetcher,
-        ttl: ttl,
-      );
-    } finally {
-      _pendingVersionKey = null;
-    }
+    Object? requestKey,
+  }) {
+    return super.getOrFetch(
+      now: now,
+      fetcher: fetcher,
+      ttl: ttl,
+      requestKey: _normalizeVersionKey(versionKey) ?? requestKey,
+    );
   }
 
   @override
@@ -201,13 +198,16 @@ class UndergraduateScoreRepository extends BaseNetCachedRepository<
     required DateTime now,
     required Future<UndergraduateScoreData> Function() fetcher,
     String? versionKey,
-  }) async {
-    _pendingVersionKey =
-        (versionKey != null && versionKey.isNotEmpty) ? versionKey : null;
-    try {
-      return await super.refresh(now: now, fetcher: fetcher);
-    } finally {
-      _pendingVersionKey = null;
-    }
+    Object? requestKey,
+  }) {
+    return super.refresh(
+      now: now,
+      fetcher: fetcher,
+      requestKey: _normalizeVersionKey(versionKey) ?? requestKey,
+    );
+  }
+
+  String? _normalizeVersionKey(String? versionKey) {
+    return versionKey != null && versionKey.isNotEmpty ? versionKey : null;
   }
 }

--- a/test/repo/course_schedule_repository_test.dart
+++ b/test/repo/course_schedule_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:onetj/models/course_schedule_data.dart';
@@ -149,6 +151,87 @@ void main() {
 
       expect(fetchCount, 1);
       expect(result.length, 2);
+    });
+
+    test('different termKey refreshes do not share an in-flight fetch',
+        () async {
+      final Completer<void> firstFetchStarted = Completer<void>();
+      final Completer<void> releaseFirstFetch = Completer<void>();
+      int firstFetchCount = 0;
+      int secondFetchCount = 0;
+
+      final Future<CourseScheduleData> firstRequest = repo.refresh(
+        now: DateTime(2026, 1, 1),
+        termKey: '2025-1',
+        fetcher: () async {
+          firstFetchCount += 1;
+          firstFetchStarted.complete();
+          await releaseFirstFetch.future;
+          return const CourseScheduleData(items: <CourseScheduleItemData>[]);
+        },
+      );
+      await firstFetchStarted.future;
+
+      final Future<CourseScheduleData> secondRequest = repo.refresh(
+        now: DateTime(2026, 1, 1),
+        termKey: '2025-2',
+        fetcher: () async {
+          secondFetchCount += 1;
+          return const CourseScheduleData(items: <CourseScheduleItemData>[]);
+        },
+      );
+      releaseFirstFetch.complete();
+
+      await Future.wait(<Future<CourseScheduleData>>[
+        firstRequest,
+        secondRequest,
+      ]);
+
+      final CourseScheduleCacheMeta? meta =
+          await repo.getCachedMeta(refreshFromStorage: true);
+      expect(firstFetchCount, 1);
+      expect(secondFetchCount, 1);
+      expect(meta?.termKey, '2025-2');
+    });
+
+    test('null and non-null termKeys do not share an in-flight fetch',
+        () async {
+      final Completer<void> firstFetchStarted = Completer<void>();
+      final Completer<void> releaseFirstFetch = Completer<void>();
+      int firstFetchCount = 0;
+      int secondFetchCount = 0;
+
+      final Future<CourseScheduleData> firstRequest = repo.getOrFetch(
+        now: DateTime(2026, 1, 1),
+        fetcher: () async {
+          firstFetchCount += 1;
+          firstFetchStarted.complete();
+          await releaseFirstFetch.future;
+          return const CourseScheduleData(items: <CourseScheduleItemData>[]);
+        },
+      );
+      await firstFetchStarted.future;
+
+      final Future<CourseScheduleData> secondRequest = repo.getOrFetch(
+        now: DateTime(2026, 1, 1),
+        termKey: '2025-1',
+        fetcher: () async {
+          secondFetchCount += 1;
+          return const CourseScheduleData(items: <CourseScheduleItemData>[]);
+        },
+      );
+      releaseFirstFetch.complete();
+
+      await Future.wait(<Future<CourseScheduleData>>[
+        firstRequest,
+        secondRequest,
+      ]);
+
+      final CourseScheduleCacheMeta? meta =
+          await repo.getCachedMeta(refreshFromStorage: true);
+      expect(firstFetchCount, 1);
+      expect(secondFetchCount, 1);
+      expect(meta?.termKey, '2025-1');
     });
 
     test('clearCache clears data and meta', () async {


### PR DESCRIPTION
## 变更说明
- 为 `BaseNetCachedRepository` 增加显式 `requestKey`：仅相同请求语义共享 in-flight Future；不同 key 在前一请求完成后再分别获取，避免单槽持久化缓存发生并发落盘错配。
- `buildMeta` 显式接收本次获取的数据和请求 key，移除 `CourseScheduleRepository` 的 `_pendingTermKey`。
- 同步移除 `StudentInfoRepository`、`UndergraduateScoreRepository` 与 `SchoolCalendarRepository` 中用于跨异步调用传递上下文的可变实例字段。
- 新增课表不同 `termKey`、以及 `null` 与非空 `termKey` 并发请求的回归测试。

## 验证
- `./scripts/flutter_test_no_proxy.ps1 test`（242 tests passed）
- `fvm flutter analyze lib/repo test/repo/course_schedule_repository_test.dart`（No issues found）
- `fvm flutter analyze` 仍会因 `local_packages/flutter_inappwebview` OpenHarmony fork 和既有文件报告 737 项问题；本次涉及范围未发现问题。