### PR TITLE
refactor: 收窄缓存请求 key 类型

### DIFF
--- a/lib/repo/base_cached_repository.dart
+++ b/lib/repo/base_cached_repository.dart
@@ -49,7 +49,7 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
   TMeta buildMeta(
     DateTime now,
     TData data, {
-    Object? requestKey,
+    String? requestKey,
   });
 
   Future<void> warmUp() async {
@@ -68,7 +68,7 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
     required Duration ttl,
     required TData? cached,
     required TMeta? meta,
-    Object? requestKey,
+    String? requestKey,
   }) {
     if (cached == null || meta == null) {
       return true;
@@ -87,7 +87,7 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
     required DateTime now,
     required Future<TData> Function() fetcher,
     Duration ttl = const Duration(days: 7),
-    Object? requestKey,
+    String? requestKey,
   }) async {
     _throwIfClearing();
     final TData? cached = _cachedData;
@@ -112,7 +112,7 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
   Future<TData> refresh({
     required DateTime now,
     required Future<TData> Function() fetcher,
-    Object? requestKey,
+    String? requestKey,
   }) {
     return _runSingleFlightFetch(
       now: now,
@@ -165,7 +165,7 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
   Future<TData> _runSingleFlightFetch({
     required DateTime now,
     required Future<TData> Function() fetcher,
-    required Object? requestKey,
+    required String? requestKey,
   }) {
     _throwIfClearing();
     final Future<TData>? inFlight = _inFlightFetch;
@@ -204,7 +204,7 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
     required Future<TData> inFlight,
     required DateTime now,
     required Future<TData> Function() fetcher,
-    required Object? requestKey,
+    required String? requestKey,
   }) async {
     try {
       await inFlight;
@@ -220,7 +220,7 @@ abstract class BaseNetCachedRepository<TData extends BaseData,
   Future<TData> _fetchAndSave({
     required DateTime now,
     required Future<TData> Function() fetcher,
-    required Object? requestKey,
+    required String? requestKey,
   }) async {
     final TData fetched = await fetcher();
     final TMeta meta = buildMeta(now, fetched, requestKey: requestKey);

--- a/lib/repo/course_schedule_repository.dart
+++ b/lib/repo/course_schedule_repository.dart
@@ -126,11 +126,11 @@ class CourseScheduleRepository extends BaseNetCachedRepository<
   CourseScheduleCacheMeta buildMeta(
     DateTime now,
     CourseScheduleData data, {
-    Object? requestKey,
+    String? requestKey,
   }) {
     return CourseScheduleCacheMeta(
       lastFetchedAtMillis: now.millisecondsSinceEpoch,
-      termKey: requestKey as String?,
+      termKey: requestKey,
     );
   }
 
@@ -158,7 +158,7 @@ class CourseScheduleRepository extends BaseNetCachedRepository<
     required Duration ttl,
     required CourseScheduleData? cached,
     required CourseScheduleCacheMeta? meta,
-    Object? requestKey,
+    String? requestKey,
   }) {
     if (meta == null || meta.termKey != requestKey) {
       return true;
@@ -178,7 +178,7 @@ class CourseScheduleRepository extends BaseNetCachedRepository<
     required Future<CourseScheduleData> Function() fetcher,
     String? termKey,
     Duration ttl = const Duration(days: 7),
-    Object? requestKey,
+    String? requestKey,
   }) {
     return super.getOrFetch(
       now: now,
@@ -193,7 +193,7 @@ class CourseScheduleRepository extends BaseNetCachedRepository<
     required DateTime now,
     required Future<CourseScheduleData> Function() fetcher,
     String? termKey,
-    Object? requestKey,
+    String? requestKey,
   }) {
     return super.refresh(
       now: now,

--- a/lib/repo/school_calendar_repository.dart
+++ b/lib/repo/school_calendar_repository.dart
@@ -125,7 +125,7 @@ class SchoolCalendarRepository extends BaseNetCachedRepository<
   SchoolCalendarCacheMeta buildMeta(
     DateTime now,
     SchoolCalendarData data, {
-    Object? requestKey,
+    String? requestKey,
   }) {
     return SchoolCalendarCacheMeta(
       lastFetchedAtMillis: now.millisecondsSinceEpoch,
@@ -139,7 +139,7 @@ class SchoolCalendarRepository extends BaseNetCachedRepository<
     required Duration ttl,
     required SchoolCalendarData? cached,
     required SchoolCalendarCacheMeta? meta,
-    Object? requestKey,
+    String? requestKey,
   }) {
     final bool baseShouldFetch = super.shouldFetch(
       now: now,
@@ -178,7 +178,7 @@ class SchoolCalendarRepository extends BaseNetCachedRepository<
     required DateTime now,
     required Future<SchoolCalendarData> Function() fetcher,
     Duration ttl = const Duration(days: 1),
-    Object? requestKey,
+    String? requestKey,
   }) {
     return super.getOrFetch(
       now: now,

--- a/lib/repo/student_info_repository.dart
+++ b/lib/repo/student_info_repository.dart
@@ -126,11 +126,11 @@ class StudentInfoRepository extends BaseNetCachedRepository<StudentInfoData,
   StudentInfoCacheMeta buildMeta(
     DateTime now,
     StudentInfoData data, {
-    Object? requestKey,
+    String? requestKey,
   }) {
     return StudentInfoCacheMeta(
       lastFetchedAtMillis: now.millisecondsSinceEpoch,
-      versionKey: requestKey as String?,
+      versionKey: requestKey,
     );
   }
 
@@ -140,7 +140,7 @@ class StudentInfoRepository extends BaseNetCachedRepository<StudentInfoData,
     required Duration ttl,
     required StudentInfoData? cached,
     required StudentInfoCacheMeta? meta,
-    Object? requestKey,
+    String? requestKey,
   }) {
     final bool shouldFetchByBase = super.shouldFetch(
       now: now,
@@ -152,7 +152,7 @@ class StudentInfoRepository extends BaseNetCachedRepository<StudentInfoData,
     if (shouldFetchByBase) {
       return true;
     }
-    final String? versionKey = requestKey as String?;
+    final String? versionKey = requestKey;
     return versionKey != null &&
         versionKey.isNotEmpty &&
         meta?.versionKey != versionKey;
@@ -182,7 +182,7 @@ class StudentInfoRepository extends BaseNetCachedRepository<StudentInfoData,
     required Future<StudentInfoData> Function() fetcher,
     String? versionKey,
     Duration ttl = const Duration(days: 7),
-    Object? requestKey,
+    String? requestKey,
   }) {
     return super.getOrFetch(
       now: now,
@@ -197,7 +197,7 @@ class StudentInfoRepository extends BaseNetCachedRepository<StudentInfoData,
     required DateTime now,
     required Future<StudentInfoData> Function() fetcher,
     String? versionKey,
-    Object? requestKey,
+    String? requestKey,
   }) {
     return super.refresh(
       now: now,

--- a/lib/repo/template_repository.dart
+++ b/lib/repo/template_repository.dart
@@ -93,7 +93,7 @@ class TemplateRepository extends BaseNetCachedRepository<TemplateData,
   TemplateCacheMeta buildMeta(
     DateTime now,
     TemplateData data, {
-    Object? requestKey,
+    String? requestKey,
   }) {
     return TemplateCacheMeta(
       lastFetchedAtMillis: now.millisecondsSinceEpoch,

--- a/lib/repo/undergraduate_score_repository.dart
+++ b/lib/repo/undergraduate_score_repository.dart
@@ -127,11 +127,11 @@ class UndergraduateScoreRepository extends BaseNetCachedRepository<
   UndergraduateScoreCacheMeta buildMeta(
     DateTime now,
     UndergraduateScoreData data, {
-    Object? requestKey,
+    String? requestKey,
   }) {
     return UndergraduateScoreCacheMeta(
       lastFetchedAtMillis: now.millisecondsSinceEpoch,
-      versionKey: requestKey as String?,
+      versionKey: requestKey,
     );
   }
 
@@ -141,7 +141,7 @@ class UndergraduateScoreRepository extends BaseNetCachedRepository<
     required Duration ttl,
     required UndergraduateScoreData? cached,
     required UndergraduateScoreCacheMeta? meta,
-    Object? requestKey,
+    String? requestKey,
   }) {
     final bool shouldFetchByBase = super.shouldFetch(
       now: now,
@@ -153,7 +153,7 @@ class UndergraduateScoreRepository extends BaseNetCachedRepository<
     if (shouldFetchByBase) {
       return true;
     }
-    final String? versionKey = requestKey as String?;
+    final String? versionKey = requestKey;
     return versionKey != null &&
         versionKey.isNotEmpty &&
         meta?.versionKey != versionKey;
@@ -183,7 +183,7 @@ class UndergraduateScoreRepository extends BaseNetCachedRepository<
     required Future<UndergraduateScoreData> Function() fetcher,
     String? versionKey,
     Duration ttl = const Duration(days: 7),
-    Object? requestKey,
+    String? requestKey,
   }) {
     return super.getOrFetch(
       now: now,
@@ -198,7 +198,7 @@ class UndergraduateScoreRepository extends BaseNetCachedRepository<
     required DateTime now,
     required Future<UndergraduateScoreData> Function() fetcher,
     String? versionKey,
-    Object? requestKey,
+    String? requestKey,
   }) {
     return super.refresh(
       now: now,


### PR DESCRIPTION
## 变更说明
- 将 `BaseNetCachedRepository` 的可选 `requestKey` API 从 `Object?` 收窄为 `String?`。
- 当前实际使用该上下文的课表学期和学生信息 / 成绩版本均为字符串；未使用请求上下文的仓库保持传递或忽略 `null`。
- 移除课表、学生信息和成绩仓库中已经不必要的 `as String?` 转换。

## 验证
- `./scripts/flutter_test_no_proxy.ps1 test`（242 tests passed）
- `fvm flutter analyze lib/repo test/repo`（No issues found）