### PR TITLE
Chore: 拆分应用代码分析入口

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,11 @@
 - On Windows, run Flutter tests via `scripts/flutter_test_no_proxy.ps1` so the
   child process can clear proxy env vars that would otherwise break local
   loopback WebSocket connections used by `flutter test`.
+- Run the app analyzer through `scripts/flutter_analyze_app.ps1`, which limits
+  analysis to `lib` and `test`.
+- Do not use bare `fvm flutter analyze` as the app-quality signal because it
+  may include local path vendor packages. Vendor changes require their own
+  validation workflow.
 
 ## Dependencies
 - HarmonyOS WebView package comes from the OpenHarmony fork of `flutter_inappwebview`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@
 - On Windows, run Flutter tests via `scripts/flutter_test_no_proxy.ps1` so the
   child process can clear proxy env vars that would otherwise break local
   loopback WebSocket connections used by `flutter test`.
-- Run the app analyzer through `scripts/flutter_analyze_app.ps1`, which limits
-  analysis to `lib` and `test`.
+- Run the app analyzer through `scripts/flutter_analyze_app.ps1` on Windows or
+  `scripts/flutter_analyze_app.sh` on Linux/macOS; both limit analysis to `lib`
+  and `test`.
 - Do not use bare `fvm flutter analyze` as the app-quality signal because it
   may include local path vendor packages. Vendor changes require their own
   validation workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,14 +195,24 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
   fvm dart format .
   ```
 
-- 使用以下命令检查应用代码质量。该脚本只分析 `lib` 和 `test`，不会将本地 `flutter_inappwebview` vendor fork 作为应用质量门禁：
+- 使用以下命令检查应用代码质量。脚本只分析 `lib` 和 `test`，不会将本地 `flutter_inappwebview` vendor fork 作为应用质量门禁：
+
+  Windows（PowerShell）：
   ```powershell
   .\scripts\flutter_analyze_app.ps1
+  ```
+
+  Linux / macOS（Bash）：
+  ```bash
+  ./scripts/flutter_analyze_app.sh
   ```
 
   默认情况下，analyzer error 会使检查失败；warning 和 info 会输出，但暂不阻断。需要严格检查时，执行：
   ```powershell
   .\scripts\flutter_analyze_app.ps1 -Strict
+  ```
+  ```bash
+  ./scripts/flutter_analyze_app.sh --strict
   ```
 
   不要使用裸 `fvm flutter analyze` 作为应用代码质量绿灯的依据。修改 `local_packages/flutter_inappwebview/**` 时，请使用独立的 vendor 校验流程。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,10 +195,17 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
   fvm dart format .
   ```
 
-- 使用 `dart analyze` 检查代码质量：
-  ```bash
-  fvm dart analyze
+- 使用以下命令检查应用代码质量。该脚本只分析 `lib` 和 `test`，不会将本地 `flutter_inappwebview` vendor fork 作为应用质量门禁：
+  ```powershell
+  .\scripts\flutter_analyze_app.ps1
   ```
+
+  默认情况下，analyzer error 会使检查失败；warning 和 info 会输出，但暂不阻断。需要严格检查时，执行：
+  ```powershell
+  .\scripts\flutter_analyze_app.ps1 -Strict
+  ```
+
+  不要使用裸 `fvm flutter analyze` 作为应用代码质量绿灯的依据。修改 `local_packages/flutter_inappwebview/**` 时，请使用独立的 vendor 校验流程。
 
 ### 3.2 命名规范
 

--- a/scripts/flutter_analyze_app.cmd
+++ b/scripts/flutter_analyze_app.cmd
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0flutter_analyze_app.ps1" %*
+exit /b %ERRORLEVEL%

--- a/scripts/flutter_analyze_app.ps1
+++ b/scripts/flutter_analyze_app.ps1
@@ -1,0 +1,26 @@
+[CmdletBinding()]
+param(
+    [switch]$Strict,
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$FlutterAnalyzeArgs
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+$qualityArgs = if ($Strict) {
+    @('--fatal-warnings', '--fatal-infos')
+} else {
+    @('--no-fatal-warnings', '--no-fatal-infos')
+}
+
+Push-Location -LiteralPath $repoRoot
+try {
+    & fvm flutter analyze lib test @qualityArgs @FlutterAnalyzeArgs
+    $exitCode = $LASTEXITCODE
+} finally {
+    Pop-Location
+}
+
+exit $exitCode

--- a/scripts/flutter_analyze_app.sh
+++ b/scripts/flutter_analyze_app.sh
@@ -22,4 +22,8 @@ if [[ "$strict" == true ]]; then
 fi
 
 cd "$repo_root"
-fvm flutter analyze lib test "${quality_args[@]}" "${analyze_args[@]}"
+if [[ ${analyze_args[@]+set} ]]; then
+  fvm flutter analyze lib test "${quality_args[@]}" "${analyze_args[@]}"
+else
+  fvm flutter analyze lib test "${quality_args[@]}"
+fi

--- a/scripts/flutter_analyze_app.sh
+++ b/scripts/flutter_analyze_app.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+strict=false
+analyze_args=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --strict)
+      strict=true
+      ;;
+    *)
+      analyze_args+=("$arg")
+      ;;
+  esac
+done
+
+quality_args=(--no-fatal-warnings --no-fatal-infos)
+if [[ "$strict" == true ]]; then
+  quality_args=(--fatal-warnings --fatal-infos)
+fi
+
+cd "$repo_root"
+fvm flutter analyze lib test "${quality_args[@]}" "${analyze_args[@]}"


### PR DESCRIPTION
## 概要

将应用代码的 analyzer 入口限定为 `lib` 与 `test`，避免本地 `flutter_inappwebview` path vendor fork 污染应用质量门禁，并补齐 Windows 与 Linux/macOS 的本地调用入口。

## 改动

- 新增 PowerShell 和 CMD 分析脚本，支持默认与严格模式。
- 新增 Linux/macOS Bash 分析脚本，并设置可执行位。
- 更新贡献与代理协作说明，明确不要用裸 `fvm flutter analyze` 作为 app 质量绿灯。

## 验证

- `./scripts/flutter_analyze_app.ps1`
- `./scripts/flutter_analyze_app.ps1 -Strict --no-pub`
- 从 `lib` 目录调用 PowerShell 脚本
- CMD 包装器（`--no-pub`）
- `./scripts/flutter_test_no_proxy.ps1`（242 tests passed）

> Bash 脚本按需求新增后未在 Linux/macOS 环境中执行；待 CI 或 Unix 环境补充验证。