### PR TITLE
fix: 移除四六级查询说明文案

### DIFF
--- a/lib/features/cet_score/views/cet_score_view.dart
+++ b/lib/features/cet_score/views/cet_score_view.dart
@@ -74,13 +74,6 @@ class _CetScoreViewState extends State<CetScoreView> {
               physics: const AlwaysScrollableScrollPhysics(),
               padding: const EdgeInsets.all(16),
               children: <Widget>[
-                Text(
-                  l10n.cetScoreSubtitle,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
-                ),
-                const SizedBox(height: 16),
                 if (records.isEmpty)
                   _EmptyState(message: l10n.cetScoreEmpty)
                 else


### PR DESCRIPTION
## 修改内容
- 移除四六级查询页顶部的说明文案及其间距。

## 验证
- `scripts/flutter_analyze_app.ps1`
- `scripts/flutter_test_no_proxy.ps1`