### PR TITLE
fix(login): 修复授权错误处理并暂时禁用未开通的考试 scope

### DIFF
--- a/lib/app/constant/site_constant.dart
+++ b/lib/app/constant/site_constant.dart
@@ -5,7 +5,9 @@ const List<String> oauthScope = [
   "rt_onetongji_undergraduate_score",
   "rt_teaching_info_undergraduate_summarized_grades", // 暂未使用
   "rt_onetongji_student_timetable",
-  "rt_onetongji_student_exams",
+// TODO: 等待学校开放平台为该 client 开通后再启用，
+// 否则授权请求会被 Keycloak 以 invalid_scope 拒绝，导致无法登录。
+//     "rt_onetongji_student_exams",
   "rt_teaching_info_sports_test_data",
   "rt_teaching_info_sports_test_health",
   "rt_onetongji_manual_arrange",

--- a/lib/app/exception/app_exception.dart
+++ b/lib/app/exception/app_exception.dart
@@ -34,6 +34,19 @@ class AuthStateMismatchException extends AppException {
       : super(errorCode, 'Auth state mismatch, possible network attack');
 }
 
+/// 授权服务器把错误重定向回 redirect_uri（如 `invalid_scope`）时抛出，
+/// 直接携带后端的 `error` / `error_description`，避免拿空 code 去换 token。
+class AuthRedirectException extends AppException {
+  static const String errorCode = 'AUTH_REDIRECT_ERROR';
+  AuthRedirectException({required String error, String? errorDescription})
+      : super(
+          errorCode,
+          errorDescription == null || errorDescription.isEmpty
+              ? 'Authorization failed: $error'
+              : 'Authorization failed: $error ($errorDescription)',
+        );
+}
+
 class NetworkException extends AppException {
   static const String _code = 'NETWORK_ERROR';
   final int? statusCode;

--- a/lib/features/login/models/login_model.dart
+++ b/lib/features/login/models/login_model.dart
@@ -41,13 +41,25 @@ class LoginModel {
   /// 处理重定向URI，提取code并交换token
   ///
   /// 如果URI不是重定向URI，返回false。
+  /// 如果重定向携带 `error`（如 `invalid_scope`）或缺少 `code`，
+  /// 抛出[AuthRedirectException]，不会拿空 code 去请求 token 接口。
   /// 如果state不匹配，抛出[AuthStateMismatchException]。
   /// 否则，调用[AuthTokenProvider.exchangeCode]交换token，并返回true。
   Future<bool> exchangeCodeIfRedirect(WebUri uri) async {
     if (!uri.toString().startsWith(_redirectUri)) {
       return false;
     }
+    final String? error = uri.queryParameters['error'];
+    if (error != null && error.isNotEmpty) {
+      throw AuthRedirectException(
+        error: error,
+        errorDescription: uri.queryParameters['error_description'],
+      );
+    }
     final code = uri.queryParameters['code'] ?? '';
+    if (code.isEmpty) {
+      throw AuthRedirectException(error: 'missing_code');
+    }
     final state = uri.queryParameters['state'] ?? '';
     if (state != _state) {
       throw AuthStateMismatchException();

--- a/test/features/login/models/login_model_test.dart
+++ b/test/features/login/models/login_model_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onetj/app/exception/app_exception.dart';
+import 'package:onetj/features/login/models/login_model.dart';
+import 'package:onetj/repo/token_repository.dart';
+import 'package:onetj/services/auth_token_provider.dart';
+
+void main() {
+  late LoginModel model;
+
+  setUp(() {
+    model = LoginModel(
+      auth: AuthTokenProvider(
+        repository: TokenRepository(storage: InMemoryTokenStorage()),
+      ),
+    );
+  });
+
+  test('非重定向URI返回false', () async {
+    final bool handled = await model.exchangeCodeIfRedirect(
+      WebUri('https://ids.tongji.edu.cn/some/page'),
+    );
+
+    expect(handled, isFalse);
+  });
+
+  test('重定向携带error时抛出AuthRedirectException并带上description', () async {
+    await expectLater(
+      model.exchangeCodeIfRedirect(
+        WebUri(
+          'https://fakeredir.jkljkluiouio.top'
+          '?error=invalid_scope&error_description=Invalid+scopes&state=abc',
+        ),
+      ),
+      throwsA(
+        isA<AuthRedirectException>().having(
+          (AuthRedirectException e) => e.message,
+          'message',
+          contains('invalid_scope'),
+        ),
+      ),
+    );
+  });
+
+  test('重定向缺少code时抛出AuthRedirectException', () async {
+    await expectLater(
+      model.exchangeCodeIfRedirect(
+        WebUri('https://fakeredir.jkljkluiouio.top?state=abc'),
+      ),
+      throwsA(
+        isA<AuthRedirectException>().having(
+          (AuthRedirectException e) => e.code,
+          'code',
+          AuthRedirectException.errorCode,
+        ),
+      ),
+    );
+  });
+
+  test('state不匹配时抛出AuthStateMismatchException', () async {
+    await expectLater(
+      model.exchangeCodeIfRedirect(
+        WebUri('https://fakeredir.jkljkluiouio.top?code=some-code&state=wrong'),
+      ),
+      throwsA(isA<AuthStateMismatchException>()),
+    );
+  });
+}


### PR DESCRIPTION
## 问题

当前 HEAD（#39 之后）构建的 APK 打开后白屏，并提示 `Code2Token parse failed: missing on field "accessToken"`。

## 根因

#39 把 OAuth scope 中原本注释的 `rt_onetongji_student_exams` 放开，但学校开放平台尚未给该 client（`authorization-xxb-onedottongji-yuchen`）开通此 scope。已用 curl 直接验证授权端点：

- 带该 scope：Keycloak 302 回 `redirect_uri?error=invalid_scope&...`，**不含 code**；
- 不带该 scope：正常 303 跳转统一身份认证。

app 拦截到错误重定向后未检查 `error` 参数，拿空 code 去请求 `/v1/token`，网关返回不含 `access_token` 的响应，解析失败后弹 SnackBar，WebView 取消导航停在白屏。

## 修改

- `site_constant.dart`：重新注释 `rt_onetongji_student_exams`，注明需等学校开通后再启用；
- `app_exception.dart`：新增 `AuthRedirectException`（`AUTH_REDIRECT_ERROR`），携带后端的 `error` / `error_description`；
- `login_model.dart`：`exchangeCodeIfRedirect` 先校验重定向中的 `error` 参数和空 `code`，直接抛出后端真实错误，不再拿空 code 换 token；
- 新增 `login_model_test.dart` 4 个用例（非重定向 URI、带 error 重定向、缺 code、state 不匹配）。

## 验证

- `scripts/flutter_analyze_app.ps1`：No issues found
- `scripts/flutter_test_no_proxy.ps1`：264 个测试全部通过