### PR TITLE
feat: 优化窄屏四列功能网格

### DIFF
--- a/lib/features/dashboard/views/widgets/function_grid.dart
+++ b/lib/features/dashboard/views/widgets/function_grid.dart
@@ -86,7 +86,7 @@ class FunctionGrid extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final bool useWideCards = constraints.maxWidth >= 720;
+        final bool useCompactLayout = constraints.maxWidth < 720;
 
         return GridView.builder(
           shrinkWrap: true,
@@ -94,12 +94,15 @@ class FunctionGrid extends StatelessWidget {
           itemCount: items.length,
           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
             crossAxisCount: 4,
-            mainAxisSpacing: 12,
-            crossAxisSpacing: 12,
-            childAspectRatio: useWideCards ? 1.2 : 1.1,
+            mainAxisSpacing: useCompactLayout ? 8 : 12,
+            crossAxisSpacing: useCompactLayout ? 8 : 12,
+            mainAxisExtent: useCompactLayout ? 88 : null,
+            childAspectRatio: 1.2,
           ),
-          itemBuilder: (context, index) =>
-              _FunctionGridCard(item: items[index]),
+          itemBuilder: (context, index) => _FunctionGridCard(
+            item: items[index],
+            compact: useCompactLayout,
+          ),
         );
       },
     );
@@ -119,47 +122,70 @@ class _FunctionGridItem {
 }
 
 class _FunctionGridCard extends StatelessWidget {
-  const _FunctionGridCard({required this.item});
+  const _FunctionGridCard({required this.item, required this.compact});
 
   final _FunctionGridItem item;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
-    return Semantics(
-      button: true,
-      label: item.label,
-      child: Card(
-        elevation: 0,
-        clipBehavior: Clip.antiAlias,
-        color: colors.surfaceContainerHighest,
-        child: InkWell(
-          onTap: item.onTap,
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Expanded(
-                  child: Image.asset(
-                    item.assetPath,
-                    fit: BoxFit.contain,
-                    filterQuality: FilterQuality.medium,
-                    excludeFromSemantics: true,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  item.label,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.titleSmall,
-                ),
-              ],
+    final Widget content = Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: compact ? 4 : 16,
+        vertical: compact ? 6 : 16,
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (compact)
+            SizedBox(
+              width: 36,
+              height: 36,
+              child: Image.asset(
+                item.assetPath,
+                fit: BoxFit.contain,
+                filterQuality: FilterQuality.medium,
+                excludeFromSemantics: true,
+              ),
+            )
+          else
+            Expanded(
+              child: Image.asset(
+                item.assetPath,
+                fit: BoxFit.contain,
+                filterQuality: FilterQuality.medium,
+                excludeFromSemantics: true,
+              ),
             ),
+          SizedBox(height: compact ? 4 : 8),
+          Text(
+            item.label,
+            maxLines: compact ? 2 : 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: compact ? TextAlign.center : null,
+            style: compact
+                ? Theme.of(context).textTheme.bodySmall
+                : Theme.of(context).textTheme.titleSmall,
           ),
-        ),
+        ],
       ),
     );
+
+    final Widget tappable = compact
+        ? Material(
+            type: MaterialType.transparency,
+            borderRadius: BorderRadius.circular(12),
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(onTap: item.onTap, child: content),
+          )
+        : Card(
+            elevation: 0,
+            clipBehavior: Clip.antiAlias,
+            color: colors.surfaceContainerHighest,
+            child: InkWell(onTap: item.onTap, child: content),
+          );
+
+    return Semantics(button: true, label: item.label, child: tappable);
   }
 }

--- a/test/features/dashboard/views/widgets/function_grid_test.dart
+++ b/test/features/dashboard/views/widgets/function_grid_test.dart
@@ -30,10 +30,13 @@ void main() {
     );
   }
 
-  int crossAxisCount(WidgetTester tester) {
+  SliverGridDelegateWithFixedCrossAxisCount gridDelegate(WidgetTester tester) {
     final GridView gridView = tester.widget<GridView>(find.byType(GridView));
-    return (gridView.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount)
-        .crossAxisCount;
+    return gridView.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+  }
+
+  int crossAxisCount(WidgetTester tester) {
+    return gridDelegate(tester).crossAxisCount;
   }
 
   testWidgets('窄屏按四列展示八个功能入口并分发点击事件', (tester) async {
@@ -44,26 +47,21 @@ void main() {
         .pumpWidget(buildFunctionGrid(onTap: (value) => selected = value));
 
     expect(find.byType(GridView), findsOneWidget);
-    expect(find.byType(Card), findsNWidgets(8));
+    expect(find.byType(Card), findsNothing);
     expect(crossAxisCount(tester), 4);
+    expect(gridDelegate(tester).mainAxisExtent, 88);
+    expect(tester.getSize(find.byType(Image).first), const Size(36, 36));
 
-    final Offset timetablePosition = tester.getTopLeft(find.text('timetable'));
-    final Offset physicsLabPosition =
-        tester.getTopLeft(find.text('physics-lab'));
-    final Offset settingsPosition = tester.getTopLeft(find.text('settings'));
-    final Offset gradesPosition = tester.getTopLeft(find.text('grades'));
-    final Offset cetScorePosition = tester.getTopLeft(find.text('cet-score'));
-    final Offset studentExamsPosition =
-        tester.getTopLeft(find.text('student-exams'));
-    final Offset toolsPosition = tester.getTopLeft(find.text('tools'));
-    final Offset aboutPosition = tester.getTopLeft(find.text('about'));
-    expect(physicsLabPosition.dy, timetablePosition.dy);
-    expect(settingsPosition.dy, timetablePosition.dy);
-    expect(gradesPosition.dy, timetablePosition.dy);
-    expect(cetScorePosition.dy, greaterThan(timetablePosition.dy));
-    expect(studentExamsPosition.dy, cetScorePosition.dy);
-    expect(toolsPosition.dy, cetScorePosition.dy);
-    expect(aboutPosition.dy, cetScorePosition.dy);
+    final Finder taps = find.byType(InkWell);
+    expect(taps, findsNWidgets(8));
+    final double firstRowCellY = tester.getTopLeft(taps.at(0)).dy;
+    expect(tester.getTopLeft(taps.at(1)).dy, firstRowCellY);
+    expect(tester.getTopLeft(taps.at(2)).dy, firstRowCellY);
+    expect(tester.getTopLeft(taps.at(3)).dy, firstRowCellY);
+    expect(tester.getTopLeft(taps.at(4)).dy, greaterThan(firstRowCellY));
+    expect(tester.getTopLeft(taps.at(5)).dy, tester.getTopLeft(taps.at(4)).dy);
+    expect(tester.getTopLeft(taps.at(6)).dy, tester.getTopLeft(taps.at(4)).dy);
+    expect(tester.getTopLeft(taps.at(7)).dy, tester.getTopLeft(taps.at(4)).dy);
 
     await tester.tap(find.text('student-exams'));
     expect(selected, 'student-exams');


### PR DESCRIPTION
## 变更说明

优化仪表盘功能入口在手机窄屏下的展示：

- 窄屏继续使用四列布局，避免两列造成的纵向占用和视觉不协调；
- 窄屏移除卡片背景，减少边框和留白；
- 缩小间距、图标和标题字号，并限制标题最多两行；
- 保留点击反馈、原有入口顺序、点击回调和无障碍语义；
- 宽屏继续使用原有 Card 风格。

## 验证

- `scripts/flutter_analyze_app.ps1` 通过
- `scripts/flutter_test_no_proxy.ps1` 通过（260 项）
- `git diff --check` 通过