### PR TITLE
build: bump OneTJ app version to 2.5.0+18

### DIFF
--- a/lib/app/constant/app_version_constant.dart
+++ b/lib/app/constant/app_version_constant.dart
@@ -1,3 +1,3 @@
 const String oneTJAppName = 'OneTJ';
-const String oneTJAppVersion = '2.4.5';
-const String oneTJAppBuildNumber = '17';
+const String oneTJAppVersion = '2.5.0';
+const String oneTJAppBuildNumber = '18';

--- a/ohos/AppScope/app.json5
+++ b/ohos/AppScope/app.json5
@@ -2,8 +2,8 @@
   "app": {
     "bundleName": "com.oierxjn.onetj",
     "vendor": "tongji",
-    "versionCode": 2004005,
-    "versionName": "2.4.5",
+    "versionCode": 2005000,
+    "versionName": "2.5.0",
     "icon": "$media:layered_image",
     "label": "$string:app_name"
   }

--- a/ohos/AppScope/resources/base/element/string.json
+++ b/ohos/AppScope/resources/base/element/string.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "app_version",
-      "value": "2.4.5"
+      "value": "2.5.0"
     }
   ]
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.4.5+17
+version: 2.5.0+18
 
 environment:
   sdk: ^3.6.2

--- a/setup.iss
+++ b/setup.iss
@@ -1,7 +1,7 @@
 [Setup]
 AppId={{e52df8a9-9166-40d9-ad95-a4d5880b9a0f}}
 AppName=OneTJ
-AppVersion=2.4.5
+AppVersion=2.5.0
 DefaultDirName={localappdata}\Programs\OneTJ
 DefaultGroupName=OneTJ
 OutputDir=dist


### PR DESCRIPTION
## 变更内容

将全项目应用版本号同步更新到 `2.5.0+18`：

- `pubspec.yaml`：`version: 2.5.0+18`
- `lib/app/constant/app_version_constant.dart`：`oneTJAppVersion = 2.5.0`、`oneTJAppBuildNumber = 18`
- `ohos/AppScope/app.json5`：`versionName: 2.5.0`、`versionCode: 2005000`（鸿蒙端映射）
- `ohos/AppScope/resources/base/element/string.json`：`app_version` → `2.5.0`
- `setup.iss`：`AppVersion=2.5.0`（Windows 安装包）

本次通过 `scripts/update_app_version.ps1` 同步，保证各处版本号一致。

## 验证

- [x] 五个版本文件已确认同步为 `2.5.0+18`