### PR TITLE
Add draft save and restore functionality for physics experiments

### DIFF
--- a/lib/app/di/dependencies.dart
+++ b/lib/app/di/dependencies.dart
@@ -5,6 +5,9 @@ import 'package:onetj/features/cet_score/application/cet_score_data_service.dart
 import 'package:onetj/features/student_exams/application/student_exam_data_service.dart';
 import 'package:onetj/features/cet_score/view_models/cet_score_view_model.dart';
 import 'package:onetj/features/student_exams/view_models/student_exam_view_model.dart';
+import 'package:onetj/features/physics_lab/features/michelson/application/michelson_draft_service.dart';
+import 'package:onetj/features/physics_lab/features/diffraction_grating/application/diffraction_grating_draft_service.dart';
+import 'package:onetj/features/physics_lab/features/franck_hertz/application/franck_hertz_draft_service.dart';
 import 'package:onetj/repo/app_update_state_repository.dart';
 import 'package:onetj/repo/cet_score_repository.dart';
 import 'package:onetj/repo/color_preset_repository.dart';
@@ -17,6 +20,7 @@ import 'package:onetj/repo/template_repository.dart';
 import 'package:onetj/repo/theme_repository.dart';
 import 'package:onetj/repo/token_repository.dart';
 import 'package:onetj/repo/undergraduate_score_repository.dart';
+import 'package:onetj/repo/physics_lab_draft_repository.dart';
 import 'package:onetj/services/app_update_api.dart';
 import 'package:onetj/services/app_update_service.dart';
 import 'package:onetj/services/auth_token_provider.dart';
@@ -53,6 +57,9 @@ void configureDependencies() {
   appLocator.registerLazySingleton<AppUpdateStateRepository>(
     AppUpdateStateRepository.new,
   );
+  appLocator.registerLazySingleton<PhysicsLabDraftRepository>(
+    PhysicsLabDraftRepository.new,
+  );
 
   // Services
   appLocator.registerLazySingleton<AuthTokenProvider>(
@@ -87,6 +94,21 @@ void configureDependencies() {
   appLocator.registerFactory<StudentExamViewModel>(
     () => StudentExamViewModel(
       dataSource: appLocator<StudentExamDataService>(),
+    ),
+  );
+  appLocator.registerLazySingleton<MichelsonDraftService>(
+    () => MichelsonDraftService(
+      repository: appLocator<PhysicsLabDraftRepository>(),
+    ),
+  );
+  appLocator.registerLazySingleton<DiffractionGratingDraftService>(
+    () => DiffractionGratingDraftService(
+      repository: appLocator<PhysicsLabDraftRepository>(),
+    ),
+  );
+  appLocator.registerLazySingleton<FranckHertzDraftService>(
+    () => FranckHertzDraftService(
+      repository: appLocator<PhysicsLabDraftRepository>(),
     ),
   );
 

--- a/lib/features/physics_lab/features/diffraction_grating/application/diffraction_grating_draft_service.dart
+++ b/lib/features/physics_lab/features/diffraction_grating/application/diffraction_grating_draft_service.dart
@@ -1,0 +1,29 @@
+import 'package:onetj/features/physics_lab/features/diffraction_grating/models/diffraction_grating_draft.dart';
+import 'package:onetj/repo/physics_lab_draft_repository.dart';
+
+/// 光栅衍射实验的草稿存取服务。
+///
+/// 持有本实验的存储 key，并负责 JSON 序列化与损坏数据防御。
+class DiffractionGratingDraftService {
+  DiffractionGratingDraftService({PhysicsLabDraftRepository? repository})
+      : _repository = repository ?? PhysicsLabDraftRepository();
+
+  static const String _key = 'diffraction_grating';
+
+  final PhysicsLabDraftRepository _repository;
+
+  Future<DiffractionGratingDraft?> load() async {
+    final String? raw = await _repository.read(_key);
+    if (raw == null || raw.isEmpty) {
+      return null;
+    }
+    try {
+      return DiffractionGratingDraft.fromJsonString(raw);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> save(DiffractionGratingDraft draft) =>
+      _repository.save(_key, draft.toJsonString());
+}

--- a/lib/features/physics_lab/features/diffraction_grating/models/diffraction_grating_draft.dart
+++ b/lib/features/physics_lab/features/diffraction_grating/models/diffraction_grating_draft.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+
+/// 光栅衍射实验的持久化草稿。
+///
+/// 只保存原始输入文本，派生结果（光栅常数、波长、相对误差）由
+/// [DiffractionGratingViewModel] 在加载后重算。
+class DiffractionGratingDraft {
+  const DiffractionGratingDraft({
+    required this.calibrationTexts,
+    required this.wavelengthTexts,
+    required this.referenceWavelengthTexts,
+    required this.calibrationReferenceText,
+  });
+
+  /// 校准读数输入文本，二维结构（行 × 读数）。
+  final List<List<String>> calibrationTexts;
+
+  /// 波长读数输入文本，三维结构（组 × 行 × 读数）。
+  final List<List<List<String>>> wavelengthTexts;
+
+  /// 各组参考波长输入文本。
+  final List<String> referenceWavelengthTexts;
+
+  /// 校准参考波长输入文本。
+  final String calibrationReferenceText;
+
+  factory DiffractionGratingDraft.fromJson(Map<String, dynamic> json) {
+    return DiffractionGratingDraft(
+      calibrationTexts: _stringList2dFromJson(json['calibrationTexts']),
+      wavelengthTexts: _stringList3dFromJson(json['wavelengthTexts']),
+      referenceWavelengthTexts:
+          _stringListFromJson(json['referenceWavelengthTexts']),
+      calibrationReferenceText:
+          json['calibrationReferenceText'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'calibrationTexts': calibrationTexts,
+        'wavelengthTexts': wavelengthTexts,
+        'referenceWavelengthTexts': referenceWavelengthTexts,
+        'calibrationReferenceText': calibrationReferenceText,
+      };
+
+  factory DiffractionGratingDraft.fromJsonString(String jsonString) {
+    return DiffractionGratingDraft.fromJson(
+      jsonDecode(jsonString) as Map<String, dynamic>,
+    );
+  }
+
+  String toJsonString() => jsonEncode(toJson());
+}
+
+List<String> _stringListFromJson(dynamic value) {
+  if (value is! List) {
+    return <String>[];
+  }
+  return value
+      .map((dynamic element) => element is String ? element : '')
+      .toList(growable: false);
+}
+
+List<List<String>> _stringList2dFromJson(dynamic value) {
+  if (value is! List) {
+    return <List<String>>[];
+  }
+  return value
+      .map((dynamic element) => _stringListFromJson(element))
+      .toList(growable: false);
+}
+
+List<List<List<String>>> _stringList3dFromJson(dynamic value) {
+  if (value is! List) {
+    return <List<List<String>>>[];
+  }
+  return value
+      .map((dynamic element) => _stringList2dFromJson(element))
+      .toList(growable: false);
+}

--- a/lib/features/physics_lab/features/diffraction_grating/view_models/diffraction_grating_view_model.dart
+++ b/lib/features/physics_lab/features/diffraction_grating/view_models/diffraction_grating_view_model.dart
@@ -5,8 +5,13 @@ import 'package:onetj/features/physics_lab/features/diffraction_grating/models/d
 import 'package:onetj/features/physics_lab/features/diffraction_grating/models/diffraction_grating_measurement_result.dart';
 import 'package:onetj/features/physics_lab/features/diffraction_grating/models/diffraction_grating_wavelength_result.dart';
 import 'package:onetj/app/presentation/base_view_model.dart';
+import 'package:onetj/features/physics_lab/features/diffraction_grating/application/diffraction_grating_draft_service.dart';
+import 'package:onetj/features/physics_lab/features/diffraction_grating/models/diffraction_grating_draft.dart';
 
 class DiffractionGratingViewModel extends BaseViewModel<Never> {
+  DiffractionGratingViewModel({DiffractionGratingDraftService? draftService})
+      : _draftService = draftService;
+
   static const int readingCountPerRow = 4;
   static const int calibrationRowCount = 1;
   static const int wavelengthGroupCount = 2;
@@ -57,6 +62,8 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       defaultCalibrationReferenceWavelengthNm.toStringAsFixed(2);
   _DiffractionGratingDerivedState? _derivedState;
 
+  final DiffractionGratingDraftService? _draftService;
+
   List<List<String>> get calibrationTexts => _clone2d(_calibrationTexts);
   List<List<List<String>>> get wavelengthTexts => _clone3d(_wavelengthTexts);
   List<String> get referenceWavelengthTexts =>
@@ -80,6 +87,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       return;
     }
     _calibrationTexts[rowIndex][readingIndex] = value;
+    _persist();
     _invalidateDerivedState();
     notifyListeners();
   }
@@ -97,6 +105,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       return;
     }
     _wavelengthTexts[groupIndex][rowIndex][readingIndex] = value;
+    _persist();
     _invalidateDerivedState();
     notifyListeners();
   }
@@ -106,6 +115,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       return;
     }
     _calibrationReferenceText = value;
+    _persist();
     _invalidateDerivedState();
     notifyListeners();
   }
@@ -118,6 +128,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       return;
     }
     _referenceWavelengthTexts[groupIndex] = value;
+    _persist();
     _invalidateDerivedState();
     notifyListeners();
   }
@@ -147,6 +158,7 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
     }
     _referenceWavelengthTexts[0] = '435.84';
     _referenceWavelengthTexts[1] = '585.94';
+    _persist();
     _invalidateDerivedState();
     notifyListeners();
   }
@@ -188,9 +200,103 @@ class DiffractionGratingViewModel extends BaseViewModel<Never> {
       }
     }
     if (changed) {
+      _persist();
       _invalidateDerivedState();
       notifyListeners();
     }
+  }
+
+  Future<void> load() async {
+    final DiffractionGratingDraftService? service = _draftService;
+    if (service == null) {
+      return;
+    }
+    final DiffractionGratingDraft? draft = await service.load();
+    if (draft == null) {
+      return;
+    }
+    if (!_hasValidCalibrationShape(draft.calibrationTexts) ||
+        !_hasValidWavelengthShape(draft.wavelengthTexts) ||
+        draft.referenceWavelengthTexts.length !=
+            _referenceWavelengthTexts.length) {
+      return;
+    }
+
+    _calibrationReferenceText = draft.calibrationReferenceText;
+    for (int rowIndex = 0;
+        rowIndex < _calibrationTexts.length;
+        rowIndex += 1) {
+      for (int readingIndex = 0;
+          readingIndex < readingCountPerRow;
+          readingIndex += 1) {
+        _calibrationTexts[rowIndex][readingIndex] =
+            draft.calibrationTexts[rowIndex][readingIndex];
+      }
+    }
+    for (int groupIndex = 0;
+        groupIndex < _wavelengthTexts.length;
+        groupIndex += 1) {
+      for (int rowIndex = 0; rowIndex < wavelengthRowCount; rowIndex += 1) {
+        for (int readingIndex = 0;
+            readingIndex < readingCountPerRow;
+            readingIndex += 1) {
+          _wavelengthTexts[groupIndex][rowIndex][readingIndex] =
+              draft.wavelengthTexts[groupIndex][rowIndex][readingIndex];
+        }
+      }
+    }
+    for (int groupIndex = 0;
+        groupIndex < _referenceWavelengthTexts.length;
+        groupIndex += 1) {
+      _referenceWavelengthTexts[groupIndex] =
+          draft.referenceWavelengthTexts[groupIndex];
+    }
+    _invalidateDerivedState();
+    notifyListeners();
+  }
+
+  void _persist() {
+    final DiffractionGratingDraftService? service = _draftService;
+    if (service == null) {
+      return;
+    }
+    service.save(
+      DiffractionGratingDraft(
+        calibrationTexts: _clone2d(_calibrationTexts),
+        wavelengthTexts: _clone3d(_wavelengthTexts),
+        referenceWavelengthTexts: List<String>.of(_referenceWavelengthTexts),
+        calibrationReferenceText: _calibrationReferenceText,
+      ),
+    );
+  }
+
+  bool _hasValidCalibrationShape(List<List<String>> values) {
+    if (values.length != _calibrationTexts.length) {
+      return false;
+    }
+    for (final List<String> row in values) {
+      if (row.length != readingCountPerRow) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _hasValidWavelengthShape(List<List<List<String>>> values) {
+    if (values.length != _wavelengthTexts.length) {
+      return false;
+    }
+    for (final List<List<String>> group in values) {
+      if (group.length != wavelengthRowCount) {
+        return false;
+      }
+      for (final List<String> row in group) {
+        if (row.length != readingCountPerRow) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   _DiffractionGratingDerivedState _getDerivedState() {

--- a/lib/features/physics_lab/features/diffraction_grating/views/diffraction_grating_view.dart
+++ b/lib/features/physics_lab/features/diffraction_grating/views/diffraction_grating_view.dart
@@ -13,7 +13,9 @@ part 'widgets/diffraction_grating_form_widgets.dart';
 const String _degreeSymbol = '\u00B0';
 
 class DiffractionGratingView extends StatefulWidget {
-  const DiffractionGratingView({super.key});
+  const DiffractionGratingView({required this.viewModel, super.key});
+
+  final DiffractionGratingViewModel viewModel;
 
   @override
   State<DiffractionGratingView> createState() => _DiffractionGratingViewState();
@@ -29,7 +31,7 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
   @override
   void initState() {
     super.initState();
-    _viewModel = DiffractionGratingViewModel();
+    _viewModel = widget.viewModel;
     _calibrationReferenceController = TextEditingController(
       text: _viewModel.calibrationReferenceText,
     );
@@ -66,6 +68,11 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
       ),
       growable: false,
     );
+    _viewModel.load().then((_) {
+      if (mounted) {
+        _syncControllersFromViewModel();
+      }
+    });
   }
 
   @override
@@ -362,6 +369,40 @@ class _DiffractionGratingViewState extends State<DiffractionGratingView> {
       r'\psi_2',
       r"\psi_2^{\prime}",
     ];
+  }
+
+  void _syncControllersFromViewModel() {
+    _calibrationReferenceController.text =
+        _viewModel.calibrationReferenceText;
+    for (int rowIndex = 0;
+        rowIndex < DiffractionGratingViewModel.calibrationRowCount;
+        rowIndex += 1) {
+      for (int readingIndex = 0;
+          readingIndex < DiffractionGratingViewModel.readingCountPerRow;
+          readingIndex += 1) {
+        _calibrationControllers[rowIndex][readingIndex].setCombinedText(
+          _viewModel.calibrationTexts[rowIndex][readingIndex],
+        );
+      }
+    }
+    for (int groupIndex = 0;
+        groupIndex < DiffractionGratingViewModel.wavelengthGroupCount;
+        groupIndex += 1) {
+      _groupReferenceControllers[groupIndex].text =
+          _viewModel.referenceWavelengthTexts[groupIndex];
+      for (int rowIndex = 0;
+          rowIndex < DiffractionGratingViewModel.wavelengthRowCount;
+          rowIndex += 1) {
+        for (int readingIndex = 0;
+            readingIndex < DiffractionGratingViewModel.readingCountPerRow;
+            readingIndex += 1) {
+          _groupControllers[groupIndex][rowIndex][readingIndex]
+              .setCombinedText(
+            _viewModel.wavelengthTexts[groupIndex][rowIndex][readingIndex],
+          );
+        }
+      }
+    }
   }
 
   void _clearAllInputs() {

--- a/lib/features/physics_lab/features/franck_hertz/application/franck_hertz_draft_service.dart
+++ b/lib/features/physics_lab/features/franck_hertz/application/franck_hertz_draft_service.dart
@@ -1,0 +1,29 @@
+import 'package:onetj/features/physics_lab/features/franck_hertz/models/franck_hertz_draft.dart';
+import 'package:onetj/repo/physics_lab_draft_repository.dart';
+
+/// 弗兰克-赫兹实验的草稿存取服务。
+///
+/// 持有本实验的存储 key，并负责 JSON 序列化与损坏数据防御。
+class FranckHertzDraftService {
+  FranckHertzDraftService({PhysicsLabDraftRepository? repository})
+      : _repository = repository ?? PhysicsLabDraftRepository();
+
+  static const String _key = 'franck_hertz';
+
+  final PhysicsLabDraftRepository _repository;
+
+  Future<FranckHertzDraft?> load() async {
+    final String? raw = await _repository.read(_key);
+    if (raw == null || raw.isEmpty) {
+      return null;
+    }
+    try {
+      return FranckHertzDraft.fromJsonString(raw);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> save(FranckHertzDraft draft) =>
+      _repository.save(_key, draft.toJsonString());
+}

--- a/lib/features/physics_lab/features/franck_hertz/models/franck_hertz_draft.dart
+++ b/lib/features/physics_lab/features/franck_hertz/models/franck_hertz_draft.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+/// 弗兰克-赫兹实验草稿中的单行测量数据。
+class FranckHertzDraftRow {
+  const FranckHertzDraftRow({
+    required this.vg2kText,
+    required this.ipText,
+  });
+
+  final String vg2kText;
+  final String ipText;
+
+  factory FranckHertzDraftRow.fromJson(Map<String, dynamic> json) {
+    return FranckHertzDraftRow(
+      vg2kText: json['vg2kText'] as String? ?? '',
+      ipText: json['ipText'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'vg2kText': vg2kText,
+        'ipText': ipText,
+      };
+}
+
+/// 弗兰克-赫兹实验的持久化草稿。
+///
+/// 只保存原始输入文本，分析结果由 [FranckHertzViewModel] 在加载后重算。
+class FranckHertzDraft {
+  const FranckHertzDraft({
+    required this.vfText,
+    required this.vg1kText,
+    required this.vg2aText,
+    required this.referenceVoltageText,
+    required this.rows,
+  });
+
+  final String vfText;
+  final String vg1kText;
+  final String vg2aText;
+  final String referenceVoltageText;
+  final List<FranckHertzDraftRow> rows;
+
+  factory FranckHertzDraft.fromJson(Map<String, dynamic> json) {
+    final dynamic rawRows = json['rows'];
+    final List<FranckHertzDraftRow> rows = rawRows is List
+        ? rawRows
+            .map(
+              (dynamic element) => FranckHertzDraftRow.fromJson(
+                element as Map<String, dynamic>,
+              ),
+            )
+            .toList(growable: false)
+        : <FranckHertzDraftRow>[];
+    return FranckHertzDraft(
+      vfText: json['vfText'] as String? ?? '',
+      vg1kText: json['vg1kText'] as String? ?? '',
+      vg2aText: json['vg2aText'] as String? ?? '',
+      referenceVoltageText: json['referenceVoltageText'] as String? ?? '',
+      rows: rows,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'vfText': vfText,
+        'vg1kText': vg1kText,
+        'vg2aText': vg2aText,
+        'referenceVoltageText': referenceVoltageText,
+        'rows': rows
+            .map((FranckHertzDraftRow row) => row.toJson())
+            .toList(growable: false),
+      };
+
+  factory FranckHertzDraft.fromJsonString(String jsonString) {
+    return FranckHertzDraft.fromJson(
+      jsonDecode(jsonString) as Map<String, dynamic>,
+    );
+  }
+
+  String toJsonString() => jsonEncode(toJson());
+}

--- a/lib/features/physics_lab/features/franck_hertz/view_models/franck_hertz_view_model.dart
+++ b/lib/features/physics_lab/features/franck_hertz/view_models/franck_hertz_view_model.dart
@@ -2,8 +2,13 @@ import 'package:onetj/features/physics_lab/features/franck_hertz/models/franck_h
 import 'package:onetj/features/physics_lab/features/franck_hertz/models/franck_hertz_measurement_row.dart';
 import 'package:onetj/features/physics_lab/features/franck_hertz/models/franck_hertz_metadata.dart';
 import 'package:onetj/app/presentation/base_view_model.dart';
+import 'package:onetj/features/physics_lab/features/franck_hertz/application/franck_hertz_draft_service.dart';
+import 'package:onetj/features/physics_lab/features/franck_hertz/models/franck_hertz_draft.dart';
 
 class FranckHertzViewModel extends BaseViewModel<Never> {
+  FranckHertzViewModel({FranckHertzDraftService? draftService})
+      : _draftService = draftService;
+
   static const int defaultRowCount = 50;
   static const String defaultReferenceVoltageText = '11.61';
   static const List<List<String>> presetRows = <List<String>>[
@@ -188,6 +193,8 @@ class FranckHertzViewModel extends BaseViewModel<Never> {
     ),
   );
 
+  final FranckHertzDraftService? _draftService;
+
   FranckHertzMetadata get metadata => FranckHertzMetadata(
         vfText: _vfText,
         vg1kText: _vg1kText,
@@ -211,6 +218,7 @@ class FranckHertzViewModel extends BaseViewModel<Never> {
       return;
     }
     _vfText = value;
+    _persist();
     notifyListeners();
   }
 
@@ -219,6 +227,7 @@ class FranckHertzViewModel extends BaseViewModel<Never> {
       return;
     }
     _vg1kText = value;
+    _persist();
     notifyListeners();
   }
 
@@ -227,6 +236,7 @@ class FranckHertzViewModel extends BaseViewModel<Never> {
       return;
     }
     _vg2aText = value;
+    _persist();
     notifyListeners();
   }
 
@@ -235,6 +245,7 @@ class FranckHertzViewModel extends BaseViewModel<Never> {
       return;
     }
     _referenceVoltageText = value;
+    _persist();
     notifyListeners();
   }
 
@@ -247,6 +258,7 @@ class FranckHertzViewModel extends BaseViewModel<Never> {
       return;
     }
     _rows[rowIndex] = row.copyWith(vg2kText: value);
+    _persist();
     notifyListeners();
   }
 
@@ -259,6 +271,7 @@ class FranckHertzViewModel extends BaseViewModel<Never> {
       return;
     }
     _rows[rowIndex] = row.copyWith(ipText: value);
+    _persist();
     notifyListeners();
   }
 
@@ -270,6 +283,7 @@ class FranckHertzViewModel extends BaseViewModel<Never> {
         ipText: '',
       ),
     );
+    _persist();
     notifyListeners();
   }
 
@@ -282,6 +296,7 @@ class FranckHertzViewModel extends BaseViewModel<Never> {
       final FranckHertzMeasurementRow row = _rows[index];
       _rows[index] = row.copyWith(index: index + 1);
     }
+    _persist();
     notifyListeners();
   }
 
@@ -310,6 +325,7 @@ class FranckHertzViewModel extends BaseViewModel<Never> {
         ipText: '',
       );
     }
+    _persist();
     notifyListeners();
   }
 
@@ -364,8 +380,59 @@ class FranckHertzViewModel extends BaseViewModel<Never> {
       }
     }
     if (changed) {
+      _persist();
       notifyListeners();
     }
+  }
+
+  Future<void> load() async {
+    final FranckHertzDraftService? service = _draftService;
+    if (service == null) {
+      return;
+    }
+    final FranckHertzDraft? draft = await service.load();
+    if (draft == null) {
+      return;
+    }
+    _vfText = draft.vfText;
+    _vg1kText = draft.vg1kText;
+    _vg2aText = draft.vg2aText;
+    _referenceVoltageText = draft.referenceVoltageText;
+    _rows.clear();
+    for (int index = 0; index < draft.rows.length; index += 1) {
+      final FranckHertzDraftRow row = draft.rows[index];
+      _rows.add(
+        FranckHertzMeasurementRow(
+          index: index + 1,
+          vg2kText: row.vg2kText,
+          ipText: row.ipText,
+        ),
+      );
+    }
+    notifyListeners();
+  }
+
+  void _persist() {
+    final FranckHertzDraftService? service = _draftService;
+    if (service == null) {
+      return;
+    }
+    service.save(
+      FranckHertzDraft(
+        vfText: _vfText,
+        vg1kText: _vg1kText,
+        vg2aText: _vg2aText,
+        referenceVoltageText: _referenceVoltageText,
+        rows: _rows
+            .map(
+              (FranckHertzMeasurementRow row) => FranckHertzDraftRow(
+                vg2kText: row.vg2kText,
+                ipText: row.ipText,
+              ),
+            )
+            .toList(growable: false),
+      ),
+    );
   }
 
   bool _isValidRowIndex(int rowIndex) {

--- a/lib/features/physics_lab/features/franck_hertz/views/franck_hertz_view.dart
+++ b/lib/features/physics_lab/features/franck_hertz/views/franck_hertz_view.dart
@@ -9,7 +9,9 @@ import 'package:onetj/features/physics_lab/widgets/physics_lab_formula.dart';
 part 'widgets/franck_hertz_form_widgets.dart';
 
 class FranckHertzView extends StatefulWidget {
-  const FranckHertzView({super.key});
+  const FranckHertzView({required this.viewModel, super.key});
+
+  final FranckHertzViewModel viewModel;
 
   @override
   State<FranckHertzView> createState() => _FranckHertzViewState();
@@ -27,7 +29,7 @@ class _FranckHertzViewState extends State<FranckHertzView> {
   @override
   void initState() {
     super.initState();
-    _viewModel = FranckHertzViewModel();
+    _viewModel = widget.viewModel;
     _vfController = TextEditingController();
     _vg1kController = TextEditingController();
     _vg2aController = TextEditingController();
@@ -37,6 +39,7 @@ class _FranckHertzViewState extends State<FranckHertzView> {
     _vg2kControllers = <TextEditingController>[];
     _ipControllers = <TextEditingController>[];
     _syncRowControllers();
+    _viewModel.load();
   }
 
   @override

--- a/lib/features/physics_lab/features/michelson/application/michelson_draft_service.dart
+++ b/lib/features/physics_lab/features/michelson/application/michelson_draft_service.dart
@@ -1,0 +1,29 @@
+import 'package:onetj/features/physics_lab/features/michelson/models/michelson_draft.dart';
+import 'package:onetj/repo/physics_lab_draft_repository.dart';
+
+/// 迈克尔逊干涉实验的草稿存取服务。
+///
+/// 持有本实验的存储 key，并负责 JSON 序列化与损坏数据防御。
+class MichelsonDraftService {
+  MichelsonDraftService({PhysicsLabDraftRepository? repository})
+      : _repository = repository ?? PhysicsLabDraftRepository();
+
+  static const String _key = 'michelson';
+
+  final PhysicsLabDraftRepository _repository;
+
+  Future<MichelsonDraft?> load() async {
+    final String? raw = await _repository.read(_key);
+    if (raw == null || raw.isEmpty) {
+      return null;
+    }
+    try {
+      return MichelsonDraft.fromJsonString(raw);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> save(MichelsonDraft draft) =>
+      _repository.save(_key, draft.toJsonString());
+}

--- a/lib/features/physics_lab/features/michelson/models/michelson_draft.dart
+++ b/lib/features/physics_lab/features/michelson/models/michelson_draft.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+
+/// 迈克尔逊干涉实验的持久化草稿。
+///
+/// 只保存原始输入文本，派生结果（差值、波长、相对误差）由
+/// [MichelsonInterferometerViewModel] 在加载后重算。
+class MichelsonDraft {
+  const MichelsonDraft({required this.positions});
+
+  /// 10 个位置读数输入文本。
+  final List<String> positions;
+
+  factory MichelsonDraft.fromJson(Map<String, dynamic> json) {
+    return MichelsonDraft(
+      positions: _stringListFromJson(json['positions']),
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'positions': positions,
+      };
+
+  factory MichelsonDraft.fromJsonString(String jsonString) {
+    return MichelsonDraft.fromJson(
+      jsonDecode(jsonString) as Map<String, dynamic>,
+    );
+  }
+
+  String toJsonString() => jsonEncode(toJson());
+}
+
+List<String> _stringListFromJson(dynamic value) {
+  if (value is! List) {
+    return <String>[];
+  }
+  return value
+      .map((dynamic element) => element is String ? element : '')
+      .toList(growable: false);
+}

--- a/lib/features/physics_lab/features/michelson/view_models/michelson_interferometer_view_model.dart
+++ b/lib/features/physics_lab/features/michelson/view_models/michelson_interferometer_view_model.dart
@@ -1,8 +1,13 @@
 import 'package:onetj/features/physics_lab/features/michelson/models/michelson_input_preset.dart';
 import 'package:onetj/features/physics_lab/features/michelson/models/michelson_measurement_result.dart';
 import 'package:onetj/app/presentation/base_view_model.dart';
+import 'package:onetj/features/physics_lab/features/michelson/application/michelson_draft_service.dart';
+import 'package:onetj/features/physics_lab/features/michelson/models/michelson_draft.dart';
 
 class MichelsonInterferometerViewModel extends BaseViewModel<Never> {
+  MichelsonInterferometerViewModel({MichelsonDraftService? draftService})
+      : _draftService = draftService;
+
   static const int positionCount = MichelsonInputPreset.expectedValueCount;
   static const int differenceOffset = 5;
   static const double referenceValue = 623.8;
@@ -30,6 +35,8 @@ class MichelsonInterferometerViewModel extends BaseViewModel<Never> {
     growable: false,
   );
 
+  final MichelsonDraftService? _draftService;
+
   List<String> get positionTexts => List<String>.unmodifiable(_positionTexts);
 
   MichelsonMeasurementResult? get result => _buildResult();
@@ -44,6 +51,7 @@ class MichelsonInterferometerViewModel extends BaseViewModel<Never> {
       return;
     }
     _positionTexts[index] = value;
+    _persist();
     notifyListeners();
   }
 
@@ -61,6 +69,7 @@ class MichelsonInterferometerViewModel extends BaseViewModel<Never> {
       changed = true;
     }
     if (changed) {
+      _persist();
       notifyListeners();
     }
   }
@@ -75,8 +84,45 @@ class MichelsonInterferometerViewModel extends BaseViewModel<Never> {
       changed = true;
     }
     if (changed) {
+      _persist();
       notifyListeners();
     }
+  }
+
+  Future<void> load() async {
+    final MichelsonDraftService? service = _draftService;
+    if (service == null) {
+      return;
+    }
+    final MichelsonDraft? draft = await service.load();
+    if (draft == null) {
+      return;
+    }
+    final List<String> values = draft.positions;
+    if (values.length != _positionTexts.length) {
+      return;
+    }
+    bool changed = false;
+    for (int index = 0; index < _positionTexts.length; index += 1) {
+      if (_positionTexts[index] == values[index]) {
+        continue;
+      }
+      _positionTexts[index] = values[index];
+      changed = true;
+    }
+    if (changed) {
+      notifyListeners();
+    }
+  }
+
+  void _persist() {
+    final MichelsonDraftService? service = _draftService;
+    if (service == null) {
+      return;
+    }
+    service.save(
+      MichelsonDraft(positions: List<String>.of(_positionTexts)),
+    );
   }
 
   MichelsonMeasurementResult? _buildResult() {

--- a/lib/features/physics_lab/features/michelson/views/michelson_interferometer_view.dart
+++ b/lib/features/physics_lab/features/michelson/views/michelson_interferometer_view.dart
@@ -8,7 +8,9 @@ import 'package:onetj/features/physics_lab/features/michelson/view_models/michel
 import 'package:onetj/features/physics_lab/widgets/physics_lab_formula.dart';
 
 class MichelsonInterferometerView extends StatefulWidget {
-  const MichelsonInterferometerView({super.key});
+  const MichelsonInterferometerView({required this.viewModel, super.key});
+
+  final MichelsonInterferometerViewModel viewModel;
 
   @override
   State<MichelsonInterferometerView> createState() =>
@@ -30,12 +32,18 @@ class _MichelsonInterferometerViewState
   @override
   void initState() {
     super.initState();
-    _viewModel = MichelsonInterferometerViewModel();
+    _viewModel = widget.viewModel;
     _controllers = List<TextEditingController>.generate(
       MichelsonInterferometerViewModel.positionCount,
       (_) => TextEditingController(),
       growable: false,
     );
+    _syncControllersFromViewModel();
+    _viewModel.load().then((_) {
+      if (mounted) {
+        _syncControllersFromViewModel();
+      }
+    });
   }
 
   @override
@@ -45,6 +53,16 @@ class _MichelsonInterferometerViewState
     }
     _viewModel.dispose();
     super.dispose();
+  }
+
+  void _syncControllersFromViewModel() {
+    for (int index = 0; index < _controllers.length; index += 1) {
+      final String text = _viewModel.positionTexts[index];
+      if (_controllers[index].text == text) {
+        continue;
+      }
+      _controllers[index].text = text;
+    }
   }
 
   @override

--- a/lib/features/physics_lab/routes.dart
+++ b/lib/features/physics_lab/routes.dart
@@ -1,10 +1,17 @@
 import 'package:go_router/go_router.dart';
 
 import 'package:onetj/app/constant/route_paths.dart';
+import 'package:onetj/app/di/dependencies.dart';
 
+import 'package:onetj/features/physics_lab/features/diffraction_grating/view_models/diffraction_grating_view_model.dart';
 import 'package:onetj/features/physics_lab/features/diffraction_grating/views/diffraction_grating_view.dart';
+import 'package:onetj/features/physics_lab/features/franck_hertz/view_models/franck_hertz_view_model.dart';
 import 'package:onetj/features/physics_lab/features/franck_hertz/views/franck_hertz_view.dart';
+import 'package:onetj/features/physics_lab/features/michelson/view_models/michelson_interferometer_view_model.dart';
 import 'package:onetj/features/physics_lab/features/michelson/views/michelson_interferometer_view.dart';
+import 'package:onetj/features/physics_lab/features/michelson/application/michelson_draft_service.dart';
+import 'package:onetj/features/physics_lab/features/diffraction_grating/application/diffraction_grating_draft_service.dart';
+import 'package:onetj/features/physics_lab/features/franck_hertz/application/franck_hertz_draft_service.dart';
 import 'package:onetj/features/physics_lab/views/physics_lab_view.dart';
 
 /// 物理实验及其子实验的 Shell 外详情页面。
@@ -17,17 +24,29 @@ final List<GoRoute> physicsLabDetailRoutes = [
       GoRoute(
         path: 'michelson',
         name: 'physics-lab-michelson',
-        builder: (context, state) => const MichelsonInterferometerView(),
+        builder: (context, state) => MichelsonInterferometerView(
+          viewModel: MichelsonInterferometerViewModel(
+            draftService: appLocator<MichelsonDraftService>(),
+          ),
+        ),
       ),
       GoRoute(
         path: 'diffraction-grating',
         name: 'physics-lab-diffraction-grating',
-        builder: (context, state) => const DiffractionGratingView(),
+        builder: (context, state) => DiffractionGratingView(
+          viewModel: DiffractionGratingViewModel(
+            draftService: appLocator<DiffractionGratingDraftService>(),
+          ),
+        ),
       ),
       GoRoute(
         path: 'franck-hertz',
         name: 'physics-lab-franck-hertz',
-        builder: (context, state) => const FranckHertzView(),
+        builder: (context, state) => FranckHertzView(
+          viewModel: FranckHertzViewModel(
+            draftService: appLocator<FranckHertzDraftService>(),
+          ),
+        ),
       ),
     ],
   ),

--- a/lib/repo/physics_lab_draft_repository.dart
+++ b/lib/repo/physics_lab_draft_repository.dart
@@ -1,0 +1,66 @@
+import 'package:hive/hive.dart';
+
+/// 物理实验草稿的存储抽象。
+///
+/// 提供 [HivePhysicsLabDraftStorage]（生产）和
+/// [InMemoryPhysicsLabDraftStorage]（测试）两种实现。
+abstract class PhysicsLabDraftStorage {
+  Future<String?> read(String key);
+  Future<void> save(String key, String value);
+}
+
+/// 基于 Hive 的物理实验草稿存储。
+class HivePhysicsLabDraftStorage implements PhysicsLabDraftStorage {
+  HivePhysicsLabDraftStorage({HiveInterface? hive}) : _hive = hive ?? Hive;
+
+  static const String _boxName = 'physics_lab_drafts';
+
+  final HiveInterface _hive;
+
+  Future<Box<String>> _openBox() async {
+    if (_hive.isBoxOpen(_boxName)) {
+      return _hive.box<String>(_boxName);
+    }
+    return _hive.openBox<String>(_boxName);
+  }
+
+  @override
+  Future<String?> read(String key) async {
+    final Box<String> box = await _openBox();
+    return box.get(key);
+  }
+
+  @override
+  Future<void> save(String key, String value) async {
+    final Box<String> box = await _openBox();
+    await box.put(key, value);
+  }
+}
+
+/// 内存中的物理实验草稿存储（用于测试）。
+class InMemoryPhysicsLabDraftStorage implements PhysicsLabDraftStorage {
+  final Map<String, String> _values = <String, String>{};
+
+  @override
+  Future<String?> read(String key) async => _values[key];
+
+  @override
+  Future<void> save(String key, String value) async {
+    _values[key] = value;
+  }
+}
+
+/// 物理实验草稿的通用键值仓库。
+///
+/// 只负责按 key 读写原始字符串，不感知具体实验；key 的语义与 JSON
+/// 序列化由各实验的 application service 负责。
+class PhysicsLabDraftRepository {
+  PhysicsLabDraftRepository({PhysicsLabDraftStorage? storage})
+      : _storage = storage ?? HivePhysicsLabDraftStorage();
+
+  final PhysicsLabDraftStorage _storage;
+
+  Future<String?> read(String key) => _storage.read(key);
+
+  Future<void> save(String key, String value) => _storage.save(key, value);
+}

--- a/test/features/physics_lab/physics_lab_draft_test.dart
+++ b/test/features/physics_lab/physics_lab_draft_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onetj/features/physics_lab/features/diffraction_grating/models/diffraction_grating_draft.dart';
+import 'package:onetj/features/physics_lab/features/franck_hertz/models/franck_hertz_draft.dart';
+import 'package:onetj/features/physics_lab/features/michelson/models/michelson_draft.dart';
+
+void main() {
+  group('MichelsonDraft', () {
+    test('round-trips through JSON', () {
+      final MichelsonDraft draft = MichelsonDraft(
+        positions: <String>['50.41310', '', '50.43227'],
+      );
+
+      final MichelsonDraft restored = MichelsonDraft.fromJsonString(
+        draft.toJsonString(),
+      );
+
+      expect(restored.toJsonString(), draft.toJsonString());
+    });
+
+    test('falls back to empty positions for missing field', () {
+      final MichelsonDraft restored = MichelsonDraft.fromJson(
+        const <String, dynamic>{},
+      );
+
+      expect(restored.positions, isEmpty);
+    });
+  });
+
+  group('DiffractionGratingDraft', () {
+    test('round-trips through JSON', () {
+      final DiffractionGratingDraft draft = DiffractionGratingDraft(
+        calibrationTexts: <List<String>>[
+          <String>['159 03', '339 03', '197 34', '17 34'],
+        ],
+        wavelengthTexts: <List<List<String>>>[
+          <List<String>>[
+            <String>['171 02', '351 02', '186 06', '6 06'],
+            <String>['163 13', '343 13', '193 41', '13 41'],
+          ],
+          <List<String>>[
+            <String>['168 26', '348 26', '188 37', '8 37'],
+            <String>['157 52', '337 52', '198 37', '18 37'],
+          ],
+        ],
+        referenceWavelengthTexts: <String>['435.84', '585.94'],
+        calibrationReferenceText: '546.07',
+      );
+
+      final DiffractionGratingDraft restored =
+          DiffractionGratingDraft.fromJsonString(draft.toJsonString());
+
+      expect(restored.toJsonString(), draft.toJsonString());
+    });
+
+    test('falls back to empty structures for missing fields', () {
+      final DiffractionGratingDraft restored = DiffractionGratingDraft.fromJson(
+        const <String, dynamic>{},
+      );
+
+      expect(restored.calibrationTexts, isEmpty);
+      expect(restored.wavelengthTexts, isEmpty);
+      expect(restored.referenceWavelengthTexts, isEmpty);
+      expect(restored.calibrationReferenceText, isEmpty);
+    });
+  });
+
+  group('FranckHertzDraft', () {
+    test('round-trips through JSON', () {
+      final FranckHertzDraft draft = FranckHertzDraft(
+        vfText: '2.5',
+        vg1kText: '1.5',
+        vg2aText: '7.0',
+        referenceVoltageText: '11.61',
+        rows: const <FranckHertzDraftRow>[
+          FranckHertzDraftRow(vg2kText: '0', ipText: '0'),
+          FranckHertzDraftRow(vg2kText: '0.5', ipText: '0.002'),
+        ],
+      );
+
+      final FranckHertzDraft restored = FranckHertzDraft.fromJsonString(
+        draft.toJsonString(),
+      );
+
+      expect(restored.toJsonString(), draft.toJsonString());
+    });
+
+    test('falls back to empty values for missing fields', () {
+      final FranckHertzDraft restored = FranckHertzDraft.fromJson(
+        const <String, dynamic>{},
+      );
+
+      expect(restored.vfText, isEmpty);
+      expect(restored.vg1kText, isEmpty);
+      expect(restored.vg2aText, isEmpty);
+      expect(restored.referenceVoltageText, isEmpty);
+      expect(restored.rows, isEmpty);
+    });
+  });
+}

--- a/test/features/physics_lab/physics_lab_draft_view_model_test.dart
+++ b/test/features/physics_lab/physics_lab_draft_view_model_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onetj/features/physics_lab/features/diffraction_grating/application/diffraction_grating_draft_service.dart';
+import 'package:onetj/features/physics_lab/features/diffraction_grating/view_models/diffraction_grating_view_model.dart';
+import 'package:onetj/features/physics_lab/features/franck_hertz/application/franck_hertz_draft_service.dart';
+import 'package:onetj/features/physics_lab/features/franck_hertz/view_models/franck_hertz_view_model.dart';
+import 'package:onetj/features/physics_lab/features/michelson/application/michelson_draft_service.dart';
+import 'package:onetj/features/physics_lab/features/michelson/view_models/michelson_interferometer_view_model.dart';
+import 'package:onetj/repo/physics_lab_draft_repository.dart';
+
+void main() {
+  late InMemoryPhysicsLabDraftStorage storage;
+  late MichelsonDraftService michelsonService;
+  late DiffractionGratingDraftService diffractionService;
+  late FranckHertzDraftService franckHertzService;
+
+  setUp(() {
+    storage = InMemoryPhysicsLabDraftStorage();
+    final PhysicsLabDraftRepository repository =
+        PhysicsLabDraftRepository(storage: storage);
+    michelsonService = MichelsonDraftService(repository: repository);
+    diffractionService = DiffractionGratingDraftService(repository: repository);
+    franckHertzService = FranckHertzDraftService(repository: repository);
+  });
+
+  test('MichelsonInterferometerViewModel persists and restores its draft',
+      () async {
+    final MichelsonInterferometerViewModel first =
+        MichelsonInterferometerViewModel(draftService: michelsonService);
+    first.updatePositionText(0, '1.0');
+    first.updatePositionText(1, '2.0');
+    await pumpEventQueue();
+
+    final MichelsonInterferometerViewModel second =
+        MichelsonInterferometerViewModel(draftService: michelsonService);
+    await second.load();
+
+    expect(second.positionTexts[0], '1.0');
+    expect(second.positionTexts[1], '2.0');
+    expect(second.positionTexts[2], isEmpty);
+
+    first.dispose();
+    second.dispose();
+  });
+
+  test('DiffractionGratingViewModel persists and restores its draft',
+      () async {
+    final DiffractionGratingViewModel first =
+        DiffractionGratingViewModel(draftService: diffractionService);
+    first.updateCalibrationReferenceText('546.07');
+    first.updateCalibrationReading(0, 0, '159 03');
+    first.updateReferenceWavelengthText(0, '435.84');
+    await pumpEventQueue();
+
+    final DiffractionGratingViewModel second =
+        DiffractionGratingViewModel(draftService: diffractionService);
+    await second.load();
+
+    expect(second.calibrationReferenceText, '546.07');
+    expect(second.calibrationTexts[0][0], '159 03');
+    expect(second.referenceWavelengthTexts[0], '435.84');
+
+    first.dispose();
+    second.dispose();
+  });
+
+  test('FranckHertzViewModel persists and restores its draft', () async {
+    final FranckHertzViewModel first =
+        FranckHertzViewModel(draftService: franckHertzService);
+    first.updateVfText('2.5');
+    first.updateRowVg2kText(0, '12.0');
+    first.updateRowIpText(0, '0.32');
+    first.addRow();
+    await pumpEventQueue();
+
+    final FranckHertzViewModel second =
+        FranckHertzViewModel(draftService: franckHertzService);
+    await second.load();
+
+    expect(second.metadata.vfText, '2.5');
+    expect(second.rows, hasLength(FranckHertzViewModel.defaultRowCount + 1));
+    expect(second.rows[0].vg2kText, '12.0');
+    expect(second.rows[0].ipText, '0.32');
+
+    first.dispose();
+    second.dispose();
+  });
+}

--- a/test/repo/physics_lab_draft_repository_test.dart
+++ b/test/repo/physics_lab_draft_repository_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onetj/repo/physics_lab_draft_repository.dart';
+
+void main() {
+  group('PhysicsLabDraftRepository', () {
+    late InMemoryPhysicsLabDraftStorage storage;
+    late PhysicsLabDraftRepository repository;
+
+    setUp(() {
+      storage = InMemoryPhysicsLabDraftStorage();
+      repository = PhysicsLabDraftRepository(storage: storage);
+    });
+
+    test('returns null before any value is saved', () async {
+      expect(await repository.read('michelson'), isNull);
+    });
+
+    test('stores and retrieves raw string values by key', () async {
+      await repository.save('michelson', '{"positions":["1.0"]}');
+      await repository.save('diffraction_grating', 'raw-json');
+
+      expect(await repository.read('michelson'), '{"positions":["1.0"]}');
+      expect(await repository.read('diffraction_grating'), 'raw-json');
+      expect(await repository.read('missing'), isNull);
+    });
+
+    test('overwrites an existing key', () async {
+      await repository.save('michelson', 'first');
+      await repository.save('michelson', 'second');
+
+      expect(await repository.read('michelson'), 'second');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds persistent draft save/restore for **all three** physics-lab experiments: Michelson interferometer, diffraction grating, and Franck-Hertz.

- A shared `PhysicsLabDraftRepository` provides a generic string key-value store backed by Hive (with an in-memory implementation for tests); it knows nothing about specific experiments.
- Each experiment owns its draft model (JSON `toJson`/`fromJson`) and its own application service, which holds the storage key and defends against corrupt data.
- Each view model persists raw input on every mutation and exposes `load()` to restore it; the views receive the view model via constructor and re-sync their `TextEditingController`s after the async load.

## Changes by experiment

### Michelson interferometer
- Added `MichelsonDraft` (`lib/features/physics_lab/features/michelson/models/michelson_draft.dart`) and `MichelsonDraftService` (`lib/features/physics_lab/features/michelson/application/michelson_draft_service.dart`).
- `MichelsonInterferometerViewModel` persists on change and restores via `load()`.
- `MichelsonInterferometerView` accepts the view model via constructor and syncs controllers after load.

### Diffraction grating
- Added `DiffractionGratingDraft` and `DiffractionGratingDraftService`.
- `DiffractionGratingViewModel` persists on change, validates restored data shape, and restores via `load()`.
- `DiffractionGratingView` accepts the view model via constructor and syncs controllers after load.

### Franck-Hertz
- Added `FranckHertzDraft` / `FranckHertzDraftRow` and `FranckHertzDraftService`.
- `FranckHertzViewModel` fully integrates persistence: `_persist()` on every mutation (metadata, rows, add/remove row, preset, clear) and `load()` restores all state.

## Dependency injection

- Registered `PhysicsLabDraftRepository` plus three per-experiment draft services (`MichelsonDraftService`, `DiffractionGratingDraftService`, `FranckHertzDraftService`) in `lib/app/di/dependencies.dart`.
- Route builders construct each view model with its injected service (`lib/features/physics_lab/routes.dart`).

## Notes

- Only raw input text is persisted; derived results are recomputed on load.
- Drafts live in a single Hive box (`physics_lab_drafts`) with one key per experiment.